### PR TITLE
3dDespike

### DIFF
--- a/descriptors/afni/3dDespike.json
+++ b/descriptors/afni/3dDespike.json
@@ -1,6 +1,6 @@
 {
   "name": "3dDespike",
-  "command-line": "3dDespike [IN_FILE]",
+  "command-line": "3dDespike [PREFIX] [IN_FILE]",
   "author": "AFNI Developers",
   "description": "Removes 'spikes' from the 3D+time input dataset and writes a new dataset with the spike values replaced by something more pleasing to the eye.",
   "url": "https://afni.nimh.nih.gov/",
@@ -12,15 +12,23 @@
       "value-key": "[IN_FILE]",
       "description": "Input file to 3ddespike.",
       "optional": false
+    },
+    {
+      "id": "prefix",
+      "name": "Prefix",
+      "type": "String",
+      "value-key": "[PREFIX]",
+      "command-line-flag": "-prefix",
+      "description": "Prefix for output file.",
+      "optional": true
     }
   ],
   "output-files": [
     {
       "name": "Out file",
       "id": "out_file",
-      "path-template": "[IN_FILE]",
-      "value-key": "[OUT_FILE]",
-      "command-line-flag": "-prefix",
+      "value-key": "[PREFIX]",
+      "path-template": "[PREFIX]",
       "optional": true,
       "description": "Output file."
     }


### PR DESCRIPTION
added `prefix` arg
tested with CPAC generated command
```
3dDespike -prefix vol0000_trans_merged_masked_despike.nii.gz 
    /ocean/projects/med220004p/rupprech/ecpac_runs/base_rbc-2/rbc-options/sub-NDARINV2VY7YYNW/wd/pipeline_RBCv0/cpac_sub-NDARINV2VY7YYNW_ses-baselineYear1Arm1/_scan_rest_run-01/func_despiked_template_211/vol0000_trans_merged_masked.nii.gz
```
This particular image was overwritten with `despiked image` hence this `despiked image` was used again for testing purpose