### PR TITLE
Set '-s' flag to be optional in fslmaths

### DIFF
--- a/descriptors/fsl/fslmaths.json
+++ b/descriptors/fsl/fslmaths.json
@@ -593,7 +593,8 @@
             "name": "Gaussian kernel filtering",
             "type": "Number",
             "description": "Create a gauss kernel of sigma mm and perform mean filtering",
-            "command-line-flag": "-s"
+            "command-line-flag": "-s",
+            "optional": true
           },
           {
             "value-key": "[OP_SUBSAMP2]",


### PR DESCRIPTION
Per title - probably missed adding the "optional" when we fixed all the other descriptors.