### PR TITLE
Make `input_image` optional in `antsApplyTransforms`

### DIFF
--- a/descriptors/ants/antsApplyTransforms.json
+++ b/descriptors/ants/antsApplyTransforms.json
@@ -36,7 +36,7 @@
       "value-key": "[INPUT_IMAGE]",
       "command-line-flag": "--input",
       "description": "Currently, the only input objects supported are image objects. However, the current framework allows for warping of other objects such as meshes and point sets.",
-      "optional": false
+      "optional": true
     },
     {
       "id": "reference_image",


### PR DESCRIPTION
Resolves #228.