### PR TITLE
arranging the args

### DIFF
--- a/descriptors/afni/3dWarp.json
+++ b/descriptors/afni/3dWarp.json
@@ -3,7 +3,7 @@
   "name": "3dWarp",
   "author": "AFNI Developers",
   "description": "Warp (spatially transform) one 3D dataset.",
-  "command-line": "3dWarp [DATASET] [MATVEC_IN2OUT] [MATVEC_OUT2IN] [TTA2MNI] [MNI2TTA] [MATPARENT] [CARD2OBLIQUE] [OBLIQUE_PARENT] [DEOBLIQUE] [OBLIQUE2CARD] [DISP_OBL_XFORM_ONLY] [LINEAR] [CUBIC] [NN] [QUINTIC] [WSINC5] [FSL_MATVEC] [NEWGRID] [GRIDSET] [ZPAD] [VERB] [PREFIX]",
+  "command-line": "3dWarp [MATVEC_IN2OUT] [MATVEC_OUT2IN] [TTA2MNI] [MNI2TTA] [MATPARENT] [CARD2OBLIQUE] [OBLIQUE_PARENT] [DEOBLIQUE] [OBLIQUE2CARD] [DISP_OBL_XFORM_ONLY] [LINEAR] [CUBIC] [NN] [QUINTIC] [WSINC5] [FSL_MATVEC] [NEWGRID] [GRIDSET] [ZPAD] [VERB] [PREFIX] [DATASET]",
   "container-image": {
     "type": "docker",
     "image": "afni/afni_make_build:AFNI_24.2.06"


### PR DESCRIPTION
Moving the args so that flags appear ahead of Prefix and Dataset.
Tested and working
```BASH
 3dWarp -deoblique -prefix /home/bshrestha/projects/Rowan/dataset/sub-NF738XGN/ses-1/anat/sub-NF738XGN_ses-1_run-2_T1w_temp_deoblique.nii.gz /home/bshrestha/projects/Rowan/dataset/sub-NF738XGN/ses-1/anat/sub-NF738XGN_ses-1_run-2_T1w_temp_3d.nii.gz
```