### PR TITLE
delete prefix when AntsApplyTransforms expects none

### DIFF
--- a/src/niwrap/ants/2.5.3/antsApplyTransforms/boutiques.json
+++ b/src/niwrap/ants/2.5.3/antsApplyTransforms/boutiques.json
@@ -285,8 +285,6 @@
               "id": "order",
               "name": "Order",
               "type": "Number",
-              "command-line-flag": "order=",
-              "command-line-flag-separator": "",
               "value-key": "[ORDER]",
               "description": "Order value.",
               "optional": true,


### PR DESCRIPTION
see #263 

I'll put up a more involved future PR for:
> go through the descriptor and see if there are more instances where it uses a prefix when AntsApplyTransforms expects none