### PR TITLE
chore(release): re-pin styx2 (sub-package version fix) + bump to 0.9.4

### DIFF
--- a/src/niwrap/project.json
+++ b/src/niwrap/project.json
@@ -1,6 +1,6 @@
 {
   "name": "niwrap",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "license": "MIT",
   "packages": [
     "afni",

--- a/tooling/compile.sh
+++ b/tooling/compile.sh
@@ -23,12 +23,14 @@ set -euo pipefail
 # releases are reproducible; bump deliberately and coordinate with the hub's
 # bundled @styx/core version (see the styx2 v1-replacement plan).
 #
-# Pinned to styx-ts main at styx-ts#27 (per-tool json-schema file names, which
-# the niwrap-json-schema distribution needs); that built on #26 (the Phase A
-# codegen gaps). Bump deliberately when adopting newer styx2 behavior.
+# Pinned to styx-ts main at styx-ts#28 (per-suite wrapper packages carry the
+# project/catalog version, not the wrapped tool version - so every niwrap_<pkg>
+# stays in lockstep with the niwrap meta release). That built on #27 (per-tool
+# json-schema file names) and #26 (Phase A codegen gaps). Bump deliberately when
+# adopting newer styx2 behavior.
 # -----------------------------------------------------------------------------
 STYX2_REPO="${STYX2_REPO:-https://github.com/styx-api/styx-ts.git}"
-STYX2_REF="${STYX2_REF:-1ae2686f5ad7299a165270824a32ce2bf4f30c40}"
+STYX2_REF="${STYX2_REF:-b47a179bf610c28db12980c707d1075695f505db}"
 
 TARGETS="${1:-python,typescript,json-schema}"
 


### PR DESCRIPTION
First styx2-compiled niwrap release.

## Changes

- **Re-pin `STYX2_REF`** in `tooling/compile.sh` to [styx-ts#28](https://github.com/styx-api/styx-ts/pull/28) (`b47a179`). That fixes a codegen bug where each per-suite Python wrapper (`niwrap_<pkg>`) carried the **wrapped tool** version instead of the niwrap project version:

  | package | before (#27) | after (#28) |
  |---|---|---|
  | `niwrap_fsl` | 6.0.4 | 0.9.4 |
  | `niwrap_afni` | 24.2.06 | 0.9.4 |
  | `niwrap_ants` | 2.5.3 | 0.9.4 |
  | ... | (tool version) | project version |

  v1 and the PyPI release history published every `niwrap_<pkg>` at the unified niwrap version, and the meta `niwrap` + the TypeScript distribution already used the project version - so this restores lockstep versioning.

- **Bump `project.json` to 0.9.4** - the first styx2-compiled release. 0.9.3 is the last v1 release and is already on PyPI (both the meta and every sub-package).

## On merge

`compile.yml` regenerates + force-pushes `styx-api/niwrap-{python,js,json-schema}` with the corrected, uniform `0.9.4` versions. After that, tag `v0.9.4` to trigger `publish-pypi.yaml`.