### PR TITLE
chore(release): 1.0.0 - first fully styx2-compiled release

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -27,6 +27,11 @@ jobs:
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v7
 
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
     - name: Compile
       run: |
         bash tooling/compile.sh python
@@ -55,6 +60,25 @@ jobs:
         echo "Built packages:"
         ls -la dist/built_packages/
 
+    - name: Validate package metadata before upload
+      run: |
+        # Guard against a mid-upload failure (which, without skip-existing, would
+        # leave a partial release on PyPI). The Summary 512-char limit is the one
+        # that bit us and `twine check` does NOT catch it, so assert it directly
+        # from the source pyprojects; twine check covers the rest.
+        python - <<'PY'
+        import glob, sys, tomllib
+        bad = []
+        for f in sorted(glob.glob("dist/niwrap-python/*/pyproject.toml")):
+            desc = tomllib.load(open(f, "rb")).get("project", {}).get("description", "")
+            if len(desc) > 512:
+                bad.append((f, len(desc)))
+        for f, n in bad:
+            print(f"::error file={f}::Summary is {n} chars (>512 PyPI limit)")
+        sys.exit(1 if bad else 0)
+        PY
+        uvx twine check dist/built_packages/*
+
     - name: Publish to PyPi
       id: pypi_publish
       uses: pypa/gh-action-pypi-publish@release/v1
@@ -62,4 +86,7 @@ jobs:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}
         verbose: true
+        # Idempotent/resumable: re-running a release (or recovering from a
+        # partial upload) skips distributions already on PyPI instead of failing.
+        skip-existing: true
         packages-dir: dist/built_packages

--- a/.github/workflows/typecheck-codegen.yml
+++ b/.github/workflows/typecheck-codegen.yml
@@ -31,6 +31,25 @@ jobs:
     - name: Compile (python + typescript)
       run: bash tooling/compile.sh python,typescript
 
+    - name: Validate Python package metadata (Summary length)
+      run: |
+        # pyproject's [project] description becomes the core-metadata Summary
+        # field, which PyPI rejects (400) above 512 chars - and `twine check`
+        # does NOT catch this, only the upload does. Assert it here so a long
+        # catalog description fails the PR instead of a partial release upload.
+        python - <<'PY'
+        import glob, sys, tomllib
+        bad = []
+        for f in sorted(glob.glob("dist/niwrap-python/*/pyproject.toml")):
+            desc = tomllib.load(open(f, "rb")).get("project", {}).get("description", "")
+            print(f"{f}: {len(desc)}")
+            if len(desc) > 512:
+                bad.append((f, len(desc)))
+        for f, n in bad:
+            print(f"::error file={f}::Summary is {n} chars (>512 PyPI limit)")
+        sys.exit(1 if bad else 0)
+        PY
+
     - name: Typecheck Python (mypy --strict)
       run: |
         python -m pip install --quiet mypy styxdefs

--- a/src/niwrap/project.json
+++ b/src/niwrap/project.json
@@ -1,6 +1,6 @@
 {
   "name": "niwrap",
-  "version": "0.9.4",
+  "version": "1.0.0",
   "license": "MIT",
   "packages": [
     "afni",

--- a/tooling/compile.sh
+++ b/tooling/compile.sh
@@ -23,14 +23,14 @@ set -euo pipefail
 # releases are reproducible; bump deliberately and coordinate with the hub's
 # bundled @styx/core version (see the styx2 v1-replacement plan).
 #
-# Pinned to styx-ts main at styx-ts#28 (per-suite wrapper packages carry the
-# project/catalog version, not the wrapped tool version - so every niwrap_<pkg>
-# stays in lockstep with the niwrap meta release). That built on #27 (per-tool
-# json-schema file names) and #26 (Phase A codegen gaps). Bump deliberately when
-# adopting newer styx2 behavior.
+# Pinned to styx-ts main at styx-ts#29 (clamp the per-suite pyproject summary to
+# PyPI's 512-char limit). Builds on #28 (wrapper packages carry the project
+# version, not the wrapped tool version), #27 (per-tool json-schema file names),
+# and #26 (Phase A codegen gaps). Bump deliberately when adopting newer styx2
+# behavior.
 # -----------------------------------------------------------------------------
 STYX2_REPO="${STYX2_REPO:-https://github.com/styx-api/styx-ts.git}"
-STYX2_REF="${STYX2_REF:-b47a179bf610c28db12980c707d1075695f505db}"
+STYX2_REF="${STYX2_REF:-fd498a98d1ddef89fffe7cc2d1839ae7accaba5f}"
 
 TARGETS="${1:-python,typescript,json-schema}"
 


### PR DESCRIPTION
First fully styx2-compiled niwrap release.

## Context

The 0.9.4 publish (PR #305) failed mid-upload: `niwrap_ants` was rejected with `400 'summary' field must be 512 characters or less`. styx2 had copied each package's full `docs.description` paragraph into pyproject's `[project] description`, which maps to PyPI's ≤512-char **Summary** field (freesurfer 631, fastsurfer 553, ants 515). Because `twine`/PyPI uploads stop on first error with no skip-existing, `niwrap` (meta) + `niwrap_afni` partially published at 0.9.4 - so **0.9.4 is burned** and this releases as **1.0.0**.

## Changes

- **Re-pin `STYX2_REF`** to [styx-ts#29](https://github.com/styx-api/styx-ts/pull/29) (`fd498a9`), which clamps the emitted Summary to ≤512 at a sentence boundary (full text stays in the README). Verified end-to-end: every niwrap distribution now passes `twine check`.
- **Bump to 1.0.0.**
- **Packaging gates** (the validation we were missing - mypy/tsc check code, nothing checked PyPI metadata):
  - `typecheck-codegen`: assert each emitted Summary ≤512. Note `twine check` does **not** catch this (only the upload does), so the check is explicit.
  - `publish-pypi`: same assertion + `twine check` before upload, and `skip-existing: true` so a partial/re-run upload is resumable instead of fatal.

## On merge

`compile.yml` regenerates the downstream repos at 1.0.0; then tag `v1.0.0` to publish.

## Follow-up (needs PyPI creds)

The orphaned `niwrap` 0.9.4 + `niwrap_afni` 0.9.4 can optionally be yanked so installs don't resolve to them (1.0.0 supersedes them regardless).