### PR TITLE
feat(hub): version-first hosted layout + compiler-lockstep gate (Phase C / N1+N2)

### DIFF
--- a/.github/workflows/hub-build.yml
+++ b/.github/workflows/hub-build.yml
@@ -1,0 +1,35 @@
+name: Hub layout + gate
+
+# Builds the version-first hosted layout the niwrap.dev hub consumes
+# (catalog.json + verbatim descriptors) and runs the compiler-lockstep gate:
+# compile every descriptor with the pinned @styx-api/core the hub bundles, so a
+# compiler regression can't ship a tool that 500s in the browser.
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  hub-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Set up Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+
+    - name: Build hosted layout
+      run: uv --directory tooling run wrap hub-build --out dist/pages
+
+    - name: Install gate deps
+      run: npm --prefix tooling/hub-gate ci
+
+    - name: Compiler-lockstep gate
+      run: node tooling/hub-gate/gate.mjs dist/pages

--- a/.github/workflows/publish-pages.yaml
+++ b/.github/workflows/publish-pages.yaml
@@ -5,10 +5,18 @@ permissions:
   pages: write
   id-token: write
 
-# Decoupled from release tags during the styx2 cutover: this builds the legacy
-# hub source bundle (symbolmaps + js dist + json-schema), and styx2 no longer
-# emits Python symbolmaps. The Pages/hub artifact pipeline is reworked in the
-# niwrap-hub "architecture A" migration (Phase C); until then run it manually.
+# Manual deploy of the niwrap.dev/niwrap/ Pages content.
+#
+# Phase C migration is mid-flight, so this publishes BOTH:
+#   - the new version-first hosted layout (index.json + <version>/catalog.json +
+#     descriptors/), which the architecture-A hub compiles in-browser; and
+#   - the legacy artefacts the currently-deployed hub still reads when the
+#     compile-in-browser path is off: the raw catalog mirror (source/), the
+#     prebuilt JSON Schema (niwrap-json-schema/), and the JS runtime bundle (js/).
+#
+# Keep the legacy artefacts until the hub's H2 data-layer swap is deployed; a
+# follow-up then drops the legacy steps and this becomes new-layout-only. The
+# dead Python symbolmaps step is already removed (styx2 emits none).
 on:
   workflow_dispatch:
 
@@ -33,6 +41,9 @@ jobs:
       with:
         ref: ${{ github.head_ref }}
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
@@ -42,54 +53,48 @@ jobs:
     - name: Setup Pages
       uses: actions/configure-pages@v6
 
-    - name: Styx compile
+    # --- New version-first hosted layout (architecture A) --------------------
+    - name: Build hosted layout
+      run: uv --directory tooling run wrap hub-build --out _site
+
+    - name: Compiler-lockstep gate
+      run: |
+        npm --prefix tooling/hub-gate ci
+        node tooling/hub-gate/gate.mjs _site
+
+    # --- Legacy artefacts (kept until the hub's H2 cutover is deployed) -------
+    - name: Styx compile (legacy json-schema + js)
       run: |
         bash tooling/compile.sh json-schema,typescript,python
 
-    - name: Build npm package
+    - name: Build npm package (legacy js bundle)
       run: |
         cd dist/niwrap-js
         npm install
         npm run build
 
-    - name: Prepare GitHub Pages content
+    - name: Add legacy hub sources + landing redirect
       run: |
-        # Create a temporary directory for GitHub Pages content
-        mkdir -p _site
+        # Raw catalog mirror (legacy catalog walker).
+        cp -r src _site/source
 
-        # Copy the source directories to the Pages site
-        if [ -d "src" ]; then
-          cp -r src _site/source
-        else
-          echo "Warning: src directory not found"
-          exit 1
-        fi
-
+        # Prebuilt JSON Schema (legacy forms).
         if [ -d "dist/niwrap-json-schema" ]; then
           cp -r dist/niwrap-json-schema _site/
         else
-          echo "Warning: dist/niwrap-json-schema directory not found"
+          echo "error: dist/niwrap-json-schema not found" >&2
           exit 1
         fi
 
-        # Copy the built JavaScript package dist folder to the Pages site
+        # JS runtime bundle (legacy command/outputs via niwrap.execute).
         if [ -d "dist/niwrap-js/dist" ]; then
           cp -r dist/niwrap-js/dist _site/js
         else
-          echo "Warning: dist/niwrap-js/dist directory not found"
+          echo "error: dist/niwrap-js/dist not found" >&2
           exit 1
         fi
 
-        # Copy the built Python symbolmaps to the Pages site, if present.
-        # styx2 does not emit symbolmaps (they are removed by the Phase C hub
-        # migration); skip rather than fail until the hub no longer needs them.
-        if [ -d "dist/niwrap-python/symbolmaps" ]; then
-          cp -r dist/niwrap-python/symbolmaps _site/python-symbolmaps
-        else
-          echo "Note: dist/niwrap-python/symbolmaps not found (styx2 emits none); skipping"
-        fi
-
-        # Create index.html that redirects to the repository
+        # Landing redirect for humans hitting the root.
         cat > _site/index.html << 'EOF'
         <!DOCTYPE html>
         <html>

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,5 +32,8 @@ jobs:
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v7
 
+    - name: Unit tests
+      run: uv --directory tooling run pytest
+
     - name: Test descriptors
       run: uv --directory tooling run wrap test

--- a/tooling/hub-gate/README.md
+++ b/tooling/hub-gate/README.md
@@ -1,0 +1,43 @@
+# hub-gate
+
+Compiler-lockstep gate for the niwrap.dev hub (Phase C / architecture A, N2).
+
+The hub no longer ships prebuilt JSON Schema or a JS runtime bundle. It bundles
+`@styx-api/core` and compiles each hosted descriptor **in the browser**, one at a
+time. The catalog build (`wrap hub-build`, and the styx2 catalog compile) instead
+*skips* a tool it can't compile - a warning, not a failure - so a compiler
+regression that drops a tool would pass the build yet 500 that exact tool in the
+hub at runtime.
+
+This gate closes that gap. With the pinned `@styx-api/core` (the version the hub
+bundles), it runs the hub's exact per-descriptor pipeline over every descriptor in
+the built layout and **fails if any single one errors**:
+
+```
+compile -> defaultPipeline -> solve -> resolveOutputs -> createContext
+        -> generateSchema + generateOutputsSchema        (forms, H3)
+        -> appEntrypoint + generateTypeScript -> sucrase  (command/outputs, H4)
+```
+
+It also asserts that the manifest's recorded compiler version matches the version
+installed here (the C8 lockstep), so the version a user sees in a snippet always
+matches `pip install niwrap`.
+
+## Run
+
+```bash
+# from the niwrap repo root
+uv --directory tooling run wrap hub-build --out dist/pages
+npm --prefix tooling/hub-gate ci
+node tooling/hub-gate/gate.mjs dist/pages
+```
+
+## Keeping it in lockstep
+
+Three pins must move together when adopting a newer compiler:
+
+1. `tooling/hub-gate/package.json` - `@styx-api/core` (what this gate compiles with).
+2. `wrap hub-build --compiler` default (recorded in `catalog.json`).
+3. The hub's bundled `@styx-api/core` (enforced hub-side, H6).
+
+The gate fails loudly if (1) and (2) disagree.

--- a/tooling/hub-gate/gate.mjs
+++ b/tooling/hub-gate/gate.mjs
@@ -1,0 +1,150 @@
+/**
+ * Compiler-lockstep gate (Phase C / architecture A, N2).
+ *
+ * The hub no longer fetches prebuilt JSON Schema / a JS bundle; it bundles
+ * `@styx-api/core` and compiles each hosted descriptor in the browser, one at a
+ * time. The catalog build, by contrast, *skips* a tool it can't compile (a
+ * warning, not a failure) - so a compiler regression that drops a tool would
+ * sail through the build yet 500 that exact tool in the hub at runtime.
+ *
+ * This gate closes that gap: with the pinned `@styx-api/core` (the version the
+ * hub bundles), it runs the hub's exact per-descriptor pipeline over every
+ * descriptor in the built layout and fails if any single one errors. It also
+ * asserts the manifest's recorded compiler version matches the installed one
+ * (the C8 lockstep).
+ *
+ * Usage:  node gate.mjs [pagesDir]      (pagesDir defaults to ./dist/pages)
+ */
+
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+
+import {
+  appEntrypoint,
+  compile,
+  createContext,
+  defaultPipeline,
+  generateOutputsSchema,
+  generateSchema,
+  generateTypeScript,
+  resolveOutputs,
+  solve,
+} from "@styx-api/core";
+import { transform } from "sucrase";
+import * as styxdefs from "styxdefs";
+
+const PROJECT = "niwrap";
+
+// `@styx-api/core`'s `exports` map doesn't expose ./package.json, so read the
+// installed version from this package's own node_modules.
+const installedCoreVersion = JSON.parse(
+  readFileSync(
+    path.join(import.meta.dirname, "node_modules", "@styx-api", "core", "package.json"),
+    "utf8",
+  ),
+).version;
+
+const pagesDir = path.resolve(process.cwd(), process.argv[2] ?? "dist/pages");
+
+function fail(message) {
+  console.error(`✗ ${message}`);
+  process.exit(1);
+}
+
+/**
+ * Mirror of the hub worker's `buildExecute`: transpile the generated TypeScript
+ * to CJS, evaluate it against the real `styxdefs`, and confirm the named execute
+ * export exists. Catches generated-code syntax errors and a missing entrypoint
+ * (which `generateTypeScript` - returning a string - cannot).
+ */
+function buildExecute(tsCode, executeName) {
+  const { code } = transform(tsCode, { transforms: ["typescript", "imports"] });
+  const module = { exports: {} };
+  const requireShim = (name) => {
+    if (name === "styxdefs") return styxdefs;
+    throw new Error(`generated code required an unexpected module: ${name}`);
+  };
+  const factory = new Function("require", "module", "exports", code);
+  factory(requireShim, module, module.exports);
+  if (typeof module.exports[executeName] !== "function") {
+    throw new Error(`generated module is missing the execute export "${executeName}"`);
+  }
+}
+
+/** The hub's exact per-descriptor pipeline. Throws if any stage fails. */
+function checkTool(descriptor, format, packageName, appName) {
+  const parsed = compile(descriptor, { format, filename: appName });
+  if (parsed.errors.length > 0) {
+    throw new Error(`parse: ${parsed.errors.map((e) => e.message).join("; ")}`);
+  }
+  const piped = defaultPipeline.apply(parsed.expr);
+  const solveResult = solve(piped.expr);
+  const outputs = resolveOutputs(piped.expr, solveResult);
+  const ctx = createContext(piped.expr, solveResult, outputs, {
+    app: parsed.meta,
+    package: { name: packageName },
+    project: { name: PROJECT },
+  });
+
+  // Forms (H3): both schemas must generate.
+  generateSchema(ctx);
+  generateOutputsSchema(ctx);
+
+  // Command/outputs (H4): entrypoint resolves and generated code transpiles+loads.
+  const entry = appEntrypoint(ctx);
+  if (!entry) throw new Error("no dispatch entrypoint (missing app id or package name)");
+  buildExecute(generateTypeScript(ctx), entry.executeFn);
+}
+
+// --- Load the built layout -------------------------------------------------
+
+const index = JSON.parse(readFileSync(path.join(pagesDir, "index.json"), "utf8"));
+const release = index.versions.find((v) => v.version === index.latest);
+if (!release) fail(`index.json: latest "${index.latest}" not found in versions`);
+
+const catalogPath = path.join(pagesDir, release.catalog);
+const catalog = JSON.parse(readFileSync(catalogPath, "utf8"));
+const catalogDir = path.dirname(catalogPath);
+
+// --- Lockstep: manifest version == the @styx-api/core we compile with --------
+
+const manifestVersion = catalog.compiler?.version;
+if (manifestVersion !== installedCoreVersion) {
+  fail(
+    `compiler lockstep violated: manifest pins @styx-api/core@${manifestVersion} ` +
+      `but the gate installed @${installedCoreVersion}. Bump them together ` +
+      `(wrap hub-build --compiler and tooling/hub-gate/package.json).`,
+  );
+}
+
+// --- Compile every descriptor the way the hub will ---------------------------
+
+console.log(
+  `Gate: compiling every descriptor in ${catalog.project}@${catalog.version} ` +
+    `with @styx-api/core@${installedCoreVersion}`,
+);
+
+let checked = 0;
+const failures = [];
+
+for (const pkg of catalog.packages) {
+  for (const app of pkg.apps) {
+    if (!app.descriptor) continue; // listed but unwrapped; the hub shows a CTA
+    checked++;
+    const id = `${pkg.name}/${app.name}`;
+    try {
+      const descriptor = readFileSync(path.join(catalogDir, app.descriptor), "utf8");
+      checkTool(descriptor, app.format, pkg.name, app.name);
+    } catch (err) {
+      failures.push({ app: id, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`\n✗ ${failures.length}/${checked} descriptors failed:`);
+  for (const f of failures) console.error(`  - ${f.app}: ${f.error}`);
+  process.exit(1);
+}
+
+console.log(`✓ all ${checked} descriptors compiled cleanly (forms + command + snippets path)`);

--- a/tooling/hub-gate/gate.mjs
+++ b/tooling/hub-gate/gate.mjs
@@ -147,4 +147,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log(`✓ all ${checked} descriptors compiled cleanly (forms + command + snippets path)`);
+console.log(`✓ all ${checked} descriptors compiled cleanly (forms + command codegen)`);

--- a/tooling/hub-gate/package-lock.json
+++ b/tooling/hub-gate/package-lock.json
@@ -1,0 +1,208 @@
+{
+  "name": "niwrap-hub-gate",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "niwrap-hub-gate",
+      "version": "0.0.0",
+      "dependencies": {
+        "@styx-api/core": "0.2.0",
+        "styxdefs": "^0.2.0",
+        "sucrase": "^3.35.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@styx-api/core": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@styx-api/core/-/core-0.2.0.tgz",
+      "integrity": "sha512-TJzdqWxa9nz5GKHVvRZFsX66iJ8mfrmrT6zCMwzVbWJ7/iHK+RN1e6DWmABf/+GSidOTL5KAnJiq/eHiIbflLg==",
+      "license": "MIT"
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/styxdefs": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/styxdefs/-/styxdefs-0.2.0.tgz",
+      "integrity": "sha512-Zy8EmMPJqyH2Wa4ODJ9tPJasnHn5c0E/KraBQdTC2u+r7YkWnJtJnNjam259htxCR7U6GMPWGRUPJROrAHgCeQ==",
+      "license": "MIT"
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/tooling/hub-gate/package.json
+++ b/tooling/hub-gate/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "niwrap-hub-gate",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Compiler-lockstep gate (Phase C / N2): compile every hosted descriptor with the pinned @styx-api/core and fail if any single one errors.",
+  "scripts": {
+    "gate": "node gate.mjs"
+  },
+  "dependencies": {
+    "@styx-api/core": "0.2.0",
+    "styxdefs": "^0.2.0",
+    "sucrase": "^3.35.0"
+  }
+}

--- a/tooling/src/wrap/apps/hub_build/__init__.py
+++ b/tooling/src/wrap/apps/hub_build/__init__.py
@@ -1,0 +1,223 @@
+"""Build the version-first hosted layout for the niwrap.dev hub.
+
+Phase C / architecture A: the hub bundles ``@styx-api/core`` and compiles
+descriptors in the browser, so the hosted layout carries only the raw descriptors
+plus a metadata manifest - no compiled (per-language) artefacts.
+
+Emitted under ``--out`` (which maps to ``niwrap.dev/niwrap/`` once published):
+
+    index.json                                releases registry (latest + versions)
+    <version>/catalog.json                    the one manifest the hub fetches
+    <version>/descriptors/<pkg>/<app>.json     verbatim descriptor copies
+
+``<version>`` is the niwrap release version (``project.json``). Each package
+contributes its default version as metadata; the descriptor path is keyed by
+``<pkg>/<app>`` (the catalog app id = its source directory / URL slug), which is
+unambiguous within a single release.
+
+The manifest deliberately carries no compiled ``@type``: the compiler owns name
+scrubbing (e.g. workbench's ``volume-create`` -> ``volume_create``), so the hub
+resolves the runtime ``@type`` by compiling the descriptor in-browser rather than
+recomputing names from the catalog id.
+"""
+
+import shutil
+from pathlib import Path
+from typing import Any, Optional
+
+from wrap.apps.find_niwrap import find_niwrap
+from wrap.catalog import AppType, DocsType, PackageType
+from wrap.catalog_niwrap import (
+    get_project_niwrap,
+    get_version_niwrap,
+    iter_apps_niwrap,
+    iter_packages_niwrap,
+)
+from wrap.utils import write_json
+
+#: Default compiler pin recorded in the manifest. Must match the ``@styx-api/core``
+#: version the hub bundles, so the rendered snippets/command line a user sees match
+#: the published ``niwrap`` package (the C8 lockstep). Override with ``--compiler``.
+DEFAULT_COMPILER = "@styx-api/core@0.2.0"
+
+#: Bump when the manifest shape changes incompatibly, so the hub can guard on it.
+SCHEMA_VERSION = 1
+
+#: Sub-directory (relative to a version's catalog.json) holding the descriptors.
+DESCRIPTOR_BASE = "descriptors"
+
+#: Cap on the embedded per-app summary; full text stays in the descriptor.
+MAX_SUMMARY_CHARS = 240
+
+
+def _summary(docs: Optional[DocsType]) -> Optional[str]:
+    """A one-line summary for gallery/search, or ``None``.
+
+    Boutiques descriptions are usually a single line; workbench descriptions lead
+    with a summary sentence and then expand over several paragraphs, so the first
+    line is the right summary in both cases. The full description stays in the
+    descriptor (and the schema the hub compiles in-browser), so this is only for
+    listings - kept short to keep the manifest lean.
+    """
+    if not docs:
+        return None
+    description = docs.get("description")
+    if not description:
+        return None
+    summary = description.split("\n", 1)[0].strip()
+    if len(summary) > MAX_SUMMARY_CHARS:
+        summary = summary[:MAX_SUMMARY_CHARS].rstrip() + "..."
+    return summary or None
+
+
+def _app_entry(pkg_name: str, app: AppType, version_dir: Path) -> dict[str, Any]:
+    """Build one app manifest entry and copy its descriptor (if any) verbatim.
+
+    Apps without a ``source`` (listed but not yet wrapped) get no ``descriptor`` /
+    ``format`` keys, so the hub shows the "not yet available" state without a fetch.
+    """
+    app_name = app["name"]
+    entry: dict[str, Any] = {"name": app_name}
+    summary = _summary(app.get("docs"))
+    if summary:
+        entry["description"] = summary
+
+    source = app.get("source")
+    if source:
+        app_dir = app["__path__"].parent
+        descriptor_src = app_dir / source["path"]
+        rel_path = f"{DESCRIPTOR_BASE}/{pkg_name}/{app_name}.json"
+        descriptor_dst = version_dir / rel_path
+        descriptor_dst.parent.mkdir(parents=True, exist_ok=True)
+        # Byte-verbatim: the gate compiles exactly what the hub will, and the file
+        # stays diffable against the source descriptor.
+        shutil.copyfile(descriptor_src, descriptor_dst)
+        entry["descriptor"] = rel_path
+        entry["format"] = source["type"]
+
+    return entry
+
+
+def _package_entry(pkg: PackageType, version_dir: Path) -> dict[str, Any]:
+    """Build one package manifest entry (its default version + that version's apps)."""
+    pkg_name = pkg["name"]
+    default_version = pkg["default"]
+    version = get_version_niwrap(pkg_name, default_version)
+
+    entry: dict[str, Any] = {
+        "name": pkg_name,
+        "version": version["name"],
+    }
+    container = version.get("container")
+    if container:
+        entry["container"] = container
+    neurodesk_id = pkg.get("neurodeskId")
+    if neurodesk_id:
+        entry["neurodeskId"] = neurodesk_id
+    docs = pkg.get("docs")
+    if docs:
+        entry["docs"] = docs
+
+    entry["apps"] = [
+        _app_entry(pkg_name, app, version_dir)
+        for app in iter_apps_niwrap(pkg_name, default_version)
+    ]
+    return entry
+
+
+def _compiler_object(spec: str) -> dict[str, str]:
+    """Split a ``name@version`` compiler spec into ``{name, version}``.
+
+    ``rfind`` so the leading ``@`` of a scoped package (``@styx-api/core``) is kept.
+    """
+    at = spec.rfind("@")
+    if at <= 0:
+        raise ValueError(f"invalid --compiler spec (want name@version): {spec!r}")
+    return {"name": spec[:at], "version": spec[at + 1 :]}
+
+
+def build_hub_layout(out_dir: Path, compiler: str) -> dict[str, int]:
+    """Walk the niwrap catalog and write the hosted layout under ``out_dir``.
+
+    Returns counts (packages / apps / descriptors) for the caller to report.
+    """
+    project = get_project_niwrap()
+    version = project["version"]
+    version_dir = out_dir / version
+
+    # Clean rebuild of this version's tree so stale descriptors can't linger.
+    if version_dir.exists():
+        shutil.rmtree(version_dir)
+
+    packages = [_package_entry(pkg, version_dir) for pkg in iter_packages_niwrap()]
+
+    catalog = {
+        "schemaVersion": SCHEMA_VERSION,
+        "project": project["name"],
+        "version": version,
+        "compiler": _compiler_object(compiler),
+        "descriptorBase": DESCRIPTOR_BASE,
+        "docs": project.get("docs", {}),
+        "packages": packages,
+    }
+    write_json(version_dir / "catalog.json", catalog)
+
+    index = {
+        "schemaVersion": SCHEMA_VERSION,
+        "project": project["name"],
+        "latest": version,
+        "versions": [
+            {
+                "version": version,
+                "catalog": f"{version}/catalog.json",
+                "compiler": compiler,
+            }
+        ],
+    }
+    write_json(out_dir / "index.json", index)
+
+    app_count = sum(len(pkg["apps"]) for pkg in packages)
+    descriptor_count = sum(
+        1 for pkg in packages for app in pkg["apps"] if "descriptor" in app
+    )
+    return {
+        "packages": len(packages),
+        "apps": app_count,
+        "descriptors": descriptor_count,
+    }
+
+
+def main(args: Any) -> int:
+    # Resolve before find_niwrap (which may chdir to the repo root) so a relative
+    # --out stays anchored to the original working directory.
+    out_dir = Path(args.out).resolve()
+    find_niwrap()
+
+    stats = build_hub_layout(out_dir, args.compiler)
+    print(
+        f"Wrote hub layout to {out_dir}: "
+        f"{stats['packages']} packages, {stats['apps']} apps, "
+        f"{stats['descriptors']} descriptors."
+    )
+    return 0
+
+
+def register_command(subparsers: Any) -> None:
+    parser = subparsers.add_parser(
+        "hub-build",
+        help="Build the version-first hosted layout for the niwrap.dev hub",
+    )
+    parser.add_argument(
+        "--out",
+        default="dist/pages",
+        help="Output directory (maps to niwrap.dev/niwrap/ when published)",
+    )
+    parser.add_argument(
+        "--compiler",
+        default=DEFAULT_COMPILER,
+        help=(
+            "Compiler pin recorded in the manifest (name@version); must match the "
+            f"@styx-api/core the hub bundles (default: {DEFAULT_COMPILER})"
+        ),
+    )
+    parser.set_defaults(func=main)

--- a/tooling/src/wrap/apps/hub_build/__init__.py
+++ b/tooling/src/wrap/apps/hub_build/__init__.py
@@ -188,10 +188,11 @@ def build_hub_layout(out_dir: Path, compiler: str) -> dict[str, int]:
 
 
 def main(args: Any) -> int:
-    # Resolve before find_niwrap (which may chdir to the repo root) so a relative
-    # --out stays anchored to the original working directory.
-    out_dir = Path(args.out).resolve()
+    # find_niwrap() lands us at the repo root (it chdir's up from tooling/ when run
+    # via `uv --directory tooling`). Resolve --out *after* it, so a relative path is
+    # anchored to the repo root - not to uv's working directory.
     find_niwrap()
+    out_dir = Path(args.out).resolve()
 
     stats = build_hub_layout(out_dir, args.compiler)
     print(

--- a/tooling/src/wrap/catalog.py
+++ b/tooling/src/wrap/catalog.py
@@ -66,7 +66,7 @@ class VersionType(TypedDict):
 
 
 class DescriptorSourceType(TypedDict):
-    type: Literal["boutiques"]
+    type: Literal["boutiques", "workbench"]
     path: str
 
 

--- a/tooling/src/wrap/cli.py
+++ b/tooling/src/wrap/cli.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 from typing import Optional, Sequence
 
-from wrap.apps import check_container, sync, test
+from wrap.apps import check_container, hub_build, sync, test
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -28,6 +28,7 @@ def create_parser() -> argparse.ArgumentParser:
     sync.register_command(subparsers)
     test.register_command(subparsers)
     check_container.register_command(subparsers)
+    hub_build.register_command(subparsers)
 
     return parser
 

--- a/tooling/src/wrap/utils.py
+++ b/tooling/src/wrap/utils.py
@@ -6,3 +6,11 @@ from typing import Any
 def read_json(p: pl.Path) -> Any:
     with p.open(encoding="utf-8") as f:
         return json.load(f)
+
+
+def write_json(p: pl.Path, data: Any) -> None:
+    """Write `data` as pretty-printed JSON, creating parent dirs as needed."""
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")

--- a/tooling/tests/test_hub_build.py
+++ b/tooling/tests/test_hub_build.py
@@ -1,0 +1,153 @@
+"""Tests for the `wrap hub-build` hosted-layout builder."""
+
+import json
+import pathlib as pl
+from typing import Any
+
+import pytest
+
+from wrap.apps.hub_build import (
+    DEFAULT_COMPILER,
+    _compiler_object,
+    _summary,
+    build_hub_layout,
+)
+
+
+def _write(path: pl.Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+@pytest.fixture
+def catalog_root(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch) -> pl.Path:
+    """A minimal niwrap catalog with a wrapped boutiques tool, a workbench tool,
+    and a listed-but-unwrapped app; cwd is set to its root."""
+    src = tmp_path / "src" / "niwrap"
+    _write(
+        src / "project.json",
+        {
+            "name": "niwrap",
+            "version": "9.9.9",
+            "license": "MIT",
+            "packages": ["demo"],
+            "docs": {"title": "Demo", "description": "Demo project."},
+        },
+    )
+    _write(
+        src / "demo" / "package.json",
+        {
+            "name": "demo",
+            "neurodeskId": "demo",
+            "versions": ["1.0"],
+            "default": "1.0",
+            "docs": {"title": "Demo Pkg", "description": "A demo package."},
+        },
+    )
+    _write(
+        src / "demo" / "1.0" / "version.json",
+        {"name": "1.0", "container": "demo/img:1.0", "apps": ["tool", "wbtool", "bare"]},
+    )
+    _write(
+        src / "demo" / "1.0" / "tool" / "app.json",
+        {
+            "name": "tool",
+            "source": {"type": "boutiques", "path": "boutiques.json"},
+            "docs": {"description": "A boutiques tool.\n\nA long second paragraph."},
+        },
+    )
+    _write(src / "demo" / "1.0" / "tool" / "boutiques.json", {"name": "tool", "x": 1})
+    _write(
+        src / "demo" / "1.0" / "wbtool" / "app.json",
+        {
+            "name": "wbtool",
+            "source": {"type": "workbench", "path": "workbench.json"},
+            "docs": {"description": "A workbench tool."},
+        },
+    )
+    _write(src / "demo" / "1.0" / "wbtool" / "workbench.json", {"name": "wbtool"})
+    # Listed in version.apps but never wrapped (no source).
+    _write(src / "demo" / "1.0" / "bare" / "app.json", {"name": "bare"})
+
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_build_hub_layout(catalog_root: pl.Path) -> None:
+    out = catalog_root / "out"
+    stats = build_hub_layout(out, DEFAULT_COMPILER)
+
+    assert stats == {"packages": 1, "apps": 3, "descriptors": 2}
+
+    index = json.loads((out / "index.json").read_text(encoding="utf-8"))
+    assert index["latest"] == "9.9.9"
+    assert index["versions"][0]["catalog"] == "9.9.9/catalog.json"
+    assert index["versions"][0]["compiler"] == DEFAULT_COMPILER
+
+    catalog = json.loads((out / "9.9.9" / "catalog.json").read_text(encoding="utf-8"))
+    assert catalog["schemaVersion"] == 1
+    assert catalog["project"] == "niwrap"
+    assert catalog["version"] == "9.9.9"
+    assert catalog["compiler"] == {"name": "@styx-api/core", "version": "0.2.0"}
+    assert catalog["descriptorBase"] == "descriptors"
+    assert catalog["docs"]["title"] == "Demo"
+    assert len(catalog["packages"]) == 1
+
+    pkg = catalog["packages"][0]
+    assert pkg["name"] == "demo"
+    assert pkg["version"] == "1.0"
+    assert pkg["container"] == "demo/img:1.0"
+    assert pkg["neurodeskId"] == "demo"
+    assert pkg["docs"]["title"] == "Demo Pkg"
+
+    apps = {a["name"]: a for a in pkg["apps"]}
+    # No compiled `@type` in the manifest: the compiler owns name scrubbing, so the
+    # hub derives @type by compiling the descriptor (see module docstring).
+    assert apps["tool"] == {
+        "name": "tool",
+        "description": "A boutiques tool.",  # first line only
+        "descriptor": "descriptors/demo/tool.json",
+        "format": "boutiques",
+    }
+    assert apps["wbtool"]["format"] == "workbench"
+    assert apps["wbtool"]["descriptor"] == "descriptors/demo/wbtool.json"
+    # Unwrapped app: name only, no descriptor / format / description.
+    assert apps["bare"] == {"name": "bare"}
+
+
+def test_descriptors_copied_verbatim(catalog_root: pl.Path) -> None:
+    out = catalog_root / "out"
+    build_hub_layout(out, DEFAULT_COMPILER)
+
+    src = catalog_root / "src" / "niwrap" / "demo" / "1.0" / "tool" / "boutiques.json"
+    dst = out / "9.9.9" / "descriptors" / "demo" / "tool.json"
+    assert dst.read_bytes() == src.read_bytes()
+
+
+def test_clean_rebuild_drops_stale_descriptors(catalog_root: pl.Path) -> None:
+    out = catalog_root / "out"
+    build_hub_layout(out, DEFAULT_COMPILER)
+    stale = out / "9.9.9" / "descriptors" / "demo" / "removed.json"
+    stale.write_text("{}", encoding="utf-8")
+
+    build_hub_layout(out, DEFAULT_COMPILER)
+    assert not stale.exists()
+
+
+def test_summary_first_line_and_cap() -> None:
+    assert _summary(None) is None
+    assert _summary({}) is None
+    assert _summary({"description": "One line.\nSecond."}) == "One line."
+    long = "x" * 300
+    out = _summary({"description": long})
+    assert out is not None and out.endswith("...") and len(out) <= 243
+
+
+def test_compiler_object_keeps_scope() -> None:
+    assert _compiler_object("@styx-api/core@0.2.0") == {
+        "name": "@styx-api/core",
+        "version": "0.2.0",
+    }
+    assert _compiler_object("styx@1.2.3") == {"name": "styx", "version": "1.2.3"}
+    with pytest.raises(ValueError):
+        _compiler_object("noversion")


### PR DESCRIPTION
Phase C of the niwrap-hub styx2 migration (architecture A). The hub bundles `@styx-api/core` and compiles descriptors in the browser, so it needs only raw descriptors + a metadata manifest - not the prebuilt per-language artefacts.

## N1 - version-first hosted layout (`wrap hub-build`)

A new Python `wrap` subcommand walks the catalog and emits, under `--out` (which maps to `niwrap.dev/niwrap/` once published):

```
index.json                                releases registry (latest + versions)
<version>/catalog.json                    one manifest the hub fetches
<version>/descriptors/<pkg>/<app>.json     verbatim boutiques/workbench copies
```

- `<version>` is the niwrap **release** version (`project.json`); each package contributes its default version as metadata. Descriptor paths are keyed by `<pkg>/<app>` (the catalog id), matching `@type` within a release.
- `catalog.json` carries: packages -> apps (+ one-line summary), container image, per-version metadata, and the `@styx-api/core` version that built it (`0.2.0`) for the lockstep gate + the hub's version pin (H6).
- **No compiled `@type` in the manifest**: the compiler owns name scrubbing (e.g. workbench `volume-create` -> `volume_create`), so the hub resolves `@type` by compiling in-browser rather than recomputing names from the catalog id (per the standing "compiler exposes names" directive).
- Manifest size: **636 KB raw / 94 KB gzip** for the full 1909-tool catalog - one cached fetch replacing ~24 index round-trips + the json-schema index.

## N2 - compiler-lockstep gate (`tooling/hub-gate`)

The catalog build *skips* tools it can't compile (a warning, not a failure), so a compiler regression could ship a tool that 500s in the browser. The gate closes that: with the pinned `@styx-api/core` (the version the hub bundles), it runs the hub's exact per-descriptor pipeline over every hosted descriptor and fails if any single one errors:

```
compile -> defaultPipeline -> solve -> resolveOutputs -> createContext
        -> generateSchema + generateOutputsSchema        (forms, H3)
        -> appEntrypoint + generateTypeScript -> sucrase  (command/outputs, H4)
```

It also asserts the manifest's recorded compiler version matches the gate's installed version (C8 lockstep). **All 1909 descriptors compile cleanly (~3.4s).**

## CI

- New `hub-build.yml`: build the layout + run the gate on every PR/push.
- `pytest` wired into `test.yml` (the new unit tests).
- `publish-pages.yaml` now also emits the new layout (gated before deploy). The legacy `source/` + `niwrap-json-schema/` + `js/` artefacts are **kept** for now because the currently-deployed hub still reads them with the compile-in-browser path off; they're dropped in a follow-up once the hub's H2 data-layer swap is deployed. The dead Python symbolmaps step is removed.

## Test plan

- [x] `ruff check` / `ruff format --check` / `mypy --strict` clean
- [x] `pytest` (5 tests: manifest shape, verbatim copy, clean rebuild, summary trimming, compiler-spec parsing)
- [x] `wrap hub-build` over the real catalog: 12 packages, 2163 apps, 1909 descriptors; bet + a workbench descriptor byte-identical to source
- [x] gate over all 1909 descriptors: pass; negative test (mismatched `--compiler`) fails as expected