### PR TITLE
fix(hub): write_json emits LF on all platforms

### DIFF
--- a/tooling/src/wrap/utils.py
+++ b/tooling/src/wrap/utils.py
@@ -9,8 +9,12 @@ def read_json(p: pl.Path) -> Any:
 
 
 def write_json(p: pl.Path, data: Any) -> None:
-    """Write `data` as pretty-printed JSON, creating parent dirs as needed."""
+    """Write `data` as pretty-printed JSON, creating parent dirs as needed.
+
+    `newline="\\n"` forces LF on every platform, so a Windows local build of the
+    hosted layout matches the Linux CI deploy byte-for-byte.
+    """
     p.parent.mkdir(parents=True, exist_ok=True)
-    with p.open("w", encoding="utf-8") as f:
+    with p.open("w", encoding="utf-8", newline="\n") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
         f.write("\n")


### PR DESCRIPTION
Tiny reproducibility follow-up to the Phase C hub layout (N1).

`tooling/src/wrap/utils.py` `write_json` opened in text mode, so a **Windows** local `wrap hub-build` emitted **CRLF** `catalog.json`/`index.json` (636 KB) while the Linux CI deploy emits LF (527 KB). `newline="\n"` forces LF everywhere, so a local build matches the deployed bytes.

Descriptors are unaffected (copied verbatim via `shutil.copyfile`).

Verified on Windows: catalog.json now 527822 bytes, 0 CR, 12578 LF (matches the live deploy). ruff/mypy/pytest green.