### PR TITLE
feat(mrtrix): serialize choice values + numeric ranges in the C++ dump

### DIFF
--- a/extraction/mrtrix/README.md
+++ b/extraction/mrtrix/README.md
@@ -30,7 +30,10 @@ applied at build time — no fork branch to rebase (the `source/` submodule
 referenced under "Legacy flow" belongs to the old flow and retires with it):
 
 - [`patches/cpp-json-usage.patch`](patches/cpp-json-usage.patch) — adds the
-  `__print_usage_json__` hook to `core/app.cpp` (pure addition, ~190 lines).
+  `__print_usage_json__` hook to `core/app.cpp` (pure addition). Per argument it
+  also serializes the constraints MRtrix keeps in `Argument::limits`: `choices`
+  for enum arguments and `min`/`max` for bounded integers/floats (the unbounded
+  sentinels are omitted) — data even MRtrix's own readthedocs docs throw away.
 - [`patches/python-argdump.patch`](patches/python-argdump.patch) — adds a
   `__print_argdump__` branch to `lib/mrtrix3/app.py` that serializes the live
   `argparse` parser (including all algorithm subparsers) with `argdump`, plus a

--- a/extraction/mrtrix/patches/cpp-json-usage.patch
+++ b/extraction/mrtrix/patches/cpp-json-usage.patch
@@ -10,6 +10,7 @@ index bcb9843ae..e1f45b87c 100644
 +      switch (t) {
 +        case Integer: return "integer";
 +        case Float: return "float";
++        case Boolean: return "boolean";
 +        case Text: return "text";
 +        case ArgFileIn: return "file in";
 +        case ArgFileOut: return "file out";
@@ -49,6 +50,34 @@ index bcb9843ae..e1f45b87c 100644
 +        }
 +        else
 +          out += s[i];
++      }
++      return out;
++    }
++
++    // Emit the constraint fields (choices / numeric range) MRtrix stores in
++    // Argument::limits, each as a trailing "key": value, line at `indent`.
++    // Unbounded ranges use sentinels (INT64 min/max, +/-inf) which are skipped.
++    static std::string arg_constraints_json (const Argument& arg, const std::string& indent) {
++      std::string out;
++      if (arg.type == Choice && arg.limits.choices) {
++        out += indent + "\"choices\": [";
++        bool first = true;
++        for (const char* const* c = arg.limits.choices; *c; ++c) {
++          if (!first) out += ", ";
++          out += std::string("\"") + json_str_escape(*c) + "\"";
++          first = false;
++        }
++        out += "],\n";
++      } else if (arg.type == Integer) {
++        if (arg.limits.i.min != std::numeric_limits<int64_t>::min())
++          out += indent + "\"min\": " + str(arg.limits.i.min) + ",\n";
++        if (arg.limits.i.max != std::numeric_limits<int64_t>::max())
++          out += indent + "\"max\": " + str(arg.limits.i.max) + ",\n";
++      } else if (arg.type == Float) {
++        if (arg.limits.f.min != -std::numeric_limits<default_type>::infinity())
++          out += indent + "\"min\": " + str(arg.limits.f.min) + ",\n";
++        if (arg.limits.f.max != std::numeric_limits<default_type>::infinity())
++          out += indent + "\"max\": " + str(arg.limits.f.max) + ",\n";
 +      }
 +      return out;
 +    }
@@ -107,6 +136,7 @@ index bcb9843ae..e1f45b87c 100644
 +        s += std::string("      \"id\": \"") + json_str_escape(ARGUMENTS[i].id) + "\",\n";
 +        s += std::string("      \"description\": \"") + json_str_escape(ARGUMENTS[i].desc) + "\",\n";
 +        s += std::string("      \"type\": \"") + arg_type_to_str(ARGUMENTS[i].type) + "\",\n";
++        s += arg_constraints_json (ARGUMENTS[i], "      ");
 +        s += std::string("      \"optional\": ") + ((ARGUMENTS[i].flags & Optional) ? "true" : "false") + ",\n";
 +        s += std::string("      \"allow_multiple\": ") + ((ARGUMENTS[i].flags & AllowMultiple) ? "true" : "false") + "\n";
 +        s += "    }";
@@ -134,6 +164,7 @@ index bcb9843ae..e1f45b87c 100644
 +            s += std::string("              \"id\": \"") + json_str_escape(OPTIONS[i][j][k].id) + "\",\n";
 +            s += std::string("              \"description\": \"") + json_str_escape(OPTIONS[i][j][k].desc) + "\",\n";
 +            s += std::string("              \"type\": \"") + arg_type_to_str(OPTIONS[i][j][k].type) + "\",\n";
++            s += arg_constraints_json (OPTIONS[i][j][k], "              ");
 +            s += std::string("              \"optional\": ") + ((OPTIONS[i][j][k].flags & Optional) ? "true" : "false") + ",\n";
 +            s += std::string("              \"allow_multiple\": ") + ((OPTIONS[i][j][k].flags & AllowMultiple) ? "true" : "false") + "\n";
 +            s += "            }";
@@ -171,6 +202,7 @@ index bcb9843ae..e1f45b87c 100644
 +          s += std::string("              \"id\": \"") + json_str_escape(__standard_options[j][k].id) + "\",\n";
 +          s += std::string("              \"description\": \"") + json_str_escape(__standard_options[j][k].desc) + "\",\n";
 +          s += std::string("              \"type\": \"") + arg_type_to_str(__standard_options[j][k].type) + "\",\n";
++          s += arg_constraints_json (__standard_options[j][k], "              ");
 +          s += std::string("              \"optional\": ") + ((__standard_options[j][k].flags & Optional) ? "true" : "false") + ",\n";
 +          s += std::string("              \"allow_multiple\": ") + ((__standard_options[j][k].flags & AllowMultiple) ? "true" : "false") + "\n";
 +          s += "            }";


### PR DESCRIPTION
## What

Extends the `__print_usage_json__` hook (`patches/cpp-json-usage.patch`) to serialize the per-argument constraints MRtrix keeps in `Argument::limits` but the dump was dropping:

- **`choices`** for `Choice` args (the `nullptr`-terminated `limits.choices`). `dwi2fod`'s `algorithm` now carries `["csd", "msmt_csd"]` instead of those values surviving only as hand-appended prose in the description.
- **`min`/`max`** for bounded `Integer`/`Float` args (`limits.i` / `limits.f`), omitting the unbounded sentinels (`INT64_MIN/MAX`, `±inf`) so a present bound is a real, tool-enforced one. (Even MRtrix's own readthedocs docs discard these.)
- Fixes a latent gap: `arg_type_to_str` omitted `Boolean`, which fell through to `"undefined"`; added the case.

Implemented as a shared `arg_constraints_json` helper (mirroring the exact field accesses + guards MRtrix's own `Argument::usage()` uses) called from all three argument loops. Pure addition; the new fields are optional so existing consumers ignore them.

## Verification

Rebuilt 3.0.4 end-to-end via the Docker pipeline: the patch applies (`git apply --recount`) and **compiles clean**, and the dump now carries **69 choice args, 267 `min` / 58 `max` bounds, with zero sentinel leakage** (e.g. `amp2sh order` -> `0..30`, `5tt2vis value` -> `0..1`).

The styx2 `mrtrix` frontend consumes these (companion PR styx-api/styx-ts#35): `choice` -> enum, `min`/`max` -> range validation. Swept the full re-dumped 123-tool catalog through Python + TS -> `mypy --strict` + `tsc` = 0 errors.

> Note: the dumps are gitignored, so this PR is just the hook change; the enriched descriptors materialize when the extraction is re-run (and feed the native cutover).