### PR TITLE
chore(release): niwrap 1.0.1 (styxkit re-export, styx-ts 0.5.0)

### DIFF
--- a/src/niwrap/project.json
+++ b/src/niwrap/project.json
@@ -1,6 +1,6 @@
 {
   "name": "niwrap",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "packages": [
     "afni",

--- a/tooling/compile.sh
+++ b/tooling/compile.sh
@@ -23,14 +23,13 @@ set -euo pipefail
 # releases are reproducible; bump deliberately and coordinate with the hub's
 # bundled @styx/core version (see the styx2 v1-replacement plan).
 #
-# Pinned to styx-ts main at the 0.4.0 release (#36) - the MRtrix `mrtrix`/
-# `argdump` frontends (#34) plus choice-enum + numeric-range support (#35).
-# Required by the MRtrix native cutover: the catalog now holds `mrtrix`/`argdump`
-# descriptors, which older styx-ts cannot compile. Keep in lockstep with the
-# hub-gate / DEFAULT_COMPILER @styx-api/core@0.4.0 pin; bump deliberately.
+# Pinned to styx-ts main at the 0.5.0 release (#41) - the metapackage now
+# re-exports styxkit so `import niwrap; niwrap.use_docker()` works again (#39),
+# plus the module-naming hardening (#40). Keep in lockstep with the hub-gate /
+# DEFAULT_COMPILER @styx-api/core@0.5.0 pin; bump deliberately.
 # -----------------------------------------------------------------------------
 STYX2_REPO="${STYX2_REPO:-https://github.com/styx-api/styx-ts.git}"
-STYX2_REF="${STYX2_REF:-b3b6dda34936d9e1ed47ddb75bb021a5cd11ab26}"
+STYX2_REF="${STYX2_REF:-7d8b41aa20a0a677deb1ce0286d01fa9fc17e2ae}"
 
 TARGETS="${1:-python,typescript,json-schema}"
 

--- a/tooling/hub-gate/package-lock.json
+++ b/tooling/hub-gate/package-lock.json
@@ -8,7 +8,7 @@
       "name": "niwrap-hub-gate",
       "version": "0.0.0",
       "dependencies": {
-        "@styx-api/core": "0.4.0",
+        "@styx-api/core": "0.5.0",
         "styxdefs": "^0.2.0",
         "sucrase": "^3.35.0"
       }
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@styx-api/core": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@styx-api/core/-/core-0.4.0.tgz",
-      "integrity": "sha512-9Fgpeciclj3sRWOABRVMv3VGSr/L1Y2AhkurMGFpL7K3Uf253Eb4HhfUyaEt5mMU4OgioFUx/WUB3ckI1dSv0w==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@styx-api/core/-/core-0.5.0.tgz",
+      "integrity": "sha512-TvexBWgAgHWdeIu19XmTlLi/sEcR+5spnR3NsVMs/pqow9/pF7yvXEjEJd4+uj5e/3c2m9lpcj0ZhY0pyY8RnA==",
       "license": "MIT"
     },
     "node_modules/any-promise": {

--- a/tooling/hub-gate/package.json
+++ b/tooling/hub-gate/package.json
@@ -8,7 +8,7 @@
     "gate": "node gate.mjs"
   },
   "dependencies": {
-    "@styx-api/core": "0.4.0",
+    "@styx-api/core": "0.5.0",
     "styxdefs": "^0.2.0",
     "sucrase": "^3.35.0"
   }

--- a/tooling/src/wrap/apps/hub_build/__init__.py
+++ b/tooling/src/wrap/apps/hub_build/__init__.py
@@ -38,7 +38,7 @@ from wrap.utils import write_json
 #: Default compiler pin recorded in the manifest. Must match the ``@styx-api/core``
 #: version the hub bundles, so the rendered snippets/command line a user sees match
 #: the published ``niwrap`` package (the C8 lockstep). Override with ``--compiler``.
-DEFAULT_COMPILER = "@styx-api/core@0.4.0"
+DEFAULT_COMPILER = "@styx-api/core@0.5.0"
 
 #: Bump when the manifest shape changes incompatibly, so the hub can guard on it.
 SCHEMA_VERSION = 1

--- a/tooling/tests/test_hub_build.py
+++ b/tooling/tests/test_hub_build.py
@@ -88,7 +88,7 @@ def test_build_hub_layout(catalog_root: pl.Path) -> None:
     assert catalog["schemaVersion"] == 1
     assert catalog["project"] == "niwrap"
     assert catalog["version"] == "9.9.9"
-    assert catalog["compiler"] == {"name": "@styx-api/core", "version": "0.4.0"}
+    assert catalog["compiler"] == {"name": "@styx-api/core", "version": "0.5.0"}
     assert catalog["descriptorBase"] == "descriptors"
     assert catalog["docs"]["title"] == "Demo"
     assert len(catalog["packages"]) == 1
@@ -144,9 +144,9 @@ def test_summary_first_line_and_cap() -> None:
 
 
 def test_compiler_object_keeps_scope() -> None:
-    assert _compiler_object("@styx-api/core@0.4.0") == {
+    assert _compiler_object("@styx-api/core@0.5.0") == {
         "name": "@styx-api/core",
-        "version": "0.4.0",
+        "version": "0.5.0",
     }
     assert _compiler_object("styx@1.2.3") == {"name": "styx", "version": "1.2.3"}
     with pytest.raises(ValueError):


### PR DESCRIPTION
## What

Cuts **niwrap 1.0.1** by bumping the styx2 compiler pin to the `@styx-api/core@0.5.0` release. The regenerated metapackage now ships an importable `niwrap/__init__.py` that re-exports [`styxkit`](https://pypi.org/project/styxkit/), restoring:

```python
import niwrap
niwrap.use_docker()      # also use_local / use_dry / use_podman / use_singularity / use_graph / use_auto
runner = niwrap.use_auto()
```

These vanished in 1.0.0 because the v2 metapackage shipped no importable module. The runner-config logic lives in the `styxkit` runtime package (the metapackage now depends on `styxkit[all]`), so this is a thin re-export, not regenerated logic.

## Changes (three-pin C8 lockstep -> `@styx-api/core@0.5.0`)

- `tooling/compile.sh` `STYX2_REF` -> `7d8b41a` (styx-ts [#41](https://github.com/styx-api/styx-ts/pull/41); includes [#39](https://github.com/styx-api/styx-ts/pull/39) re-export + [#40](https://github.com/styx-api/styx-ts/pull/40) hardening)
- `tooling/hub-gate` `@styx-api/core` 0.4.0 -> 0.5.0 (+ lockfile)
- `hub_build` `DEFAULT_COMPILER` -> `@styx-api/core@0.5.0` (+ test assertions)
- catalog `src/niwrap/project.json` version 1.0.0 -> 1.0.1

## Validation

`typecheck-codegen` CI compiles the full catalog with the new pin and runs `mypy --strict` + `tsc --noEmit` over the generated Python/TypeScript - so this PR validates the styxkit re-export end-to-end across the whole catalog before tagging. Merge, then push `v1.0.1` to trigger the PyPI publish.
