### PR TITLE
chore(ci): bump pinned GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/hub-build.yml
+++ b/.github/workflows/hub-build.yml
@@ -18,7 +18,8 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      # full pin: setup-uv stopped publishing rolling major tags (@v8) at v8
+      uses: astral-sh/setup-uv@v8.2.0
 
     - name: Set up Node
       uses: actions/setup-node@v6
@@ -41,7 +42,7 @@ jobs:
     # build-embeddings step pins env.cacheDir to tooling/hub-embed/.cache (outside
     # node_modules, so `npm ci` above doesn't wipe it); this path must match.
     - name: Cache embedding model
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: tooling/hub-embed/.cache
         key: hf-${{ hashFiles('tooling/hub-embed/package-lock.json') }}-Xenova-all-MiniLM-L6-v2

--- a/.github/workflows/publish-pages.yaml
+++ b/.github/workflows/publish-pages.yaml
@@ -34,7 +34,8 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      # full pin: setup-uv stopped publishing rolling major tags (@v8) at v8
+      uses: astral-sh/setup-uv@v8.2.0
 
     - name: Set up Node
       uses: actions/setup-node@v6
@@ -59,7 +60,7 @@ jobs:
     # build-embeddings step pins env.cacheDir to tooling/hub-embed/.cache (outside
     # node_modules, so `npm ci` above doesn't wipe it); this path must match.
     - name: Cache embedding model
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: tooling/hub-embed/.cache
         key: hf-${{ hashFiles('tooling/hub-embed/package-lock.json') }}-Xenova-all-MiniLM-L6-v2
@@ -88,7 +89,7 @@ jobs:
         EOF
 
     - name: Cache OG card assets (fonts + rasterized logo)
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: tooling/og/.assets
         key: og-assets-v1-${{ hashFiles('logo.svg') }}

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -20,15 +20,16 @@ jobs:
         ref: ${{ github.head_ref }}
 
     - name: Set up Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '22'
 
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v7
+      # full pin: setup-uv stopped publishing rolling major tags (@v8) at v8
+      uses: astral-sh/setup-uv@v8.2.0
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,7 +17,8 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v7
+      # full pin: setup-uv stopped publishing rolling major tags (@v8) at v8
+      uses: astral-sh/setup-uv@v8.2.0
 
     - name: Synchronize metadata
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,8 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v7
+      # full pin: setup-uv stopped publishing rolling major tags (@v8) at v8
+      uses: astral-sh/setup-uv@v8.2.0
 
     - name: Ruff check
       run: uv --directory tooling run ruff check src/
@@ -30,7 +31,8 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v7
+      # full pin: setup-uv stopped publishing rolling major tags (@v8) at v8
+      uses: astral-sh/setup-uv@v8.2.0
 
     - name: Unit tests
       run: uv --directory tooling run pytest

--- a/.github/workflows/typecheck-codegen.yml
+++ b/.github/workflows/typecheck-codegen.yml
@@ -19,12 +19,12 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '22'
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 


### PR DESCRIPTION
Sweep of every workflow's action pins, prompted by the Node 20-runtime deprecation GitHub flagged on `actions/cache@v4` during the last Pages deploy. Bumped everything that was behind to its current major.

## Changes

| Action | From | To | Files |
|---|---|---|---|
| `actions/cache` | `v4` | `v5` | hub-build, publish-pages (×2) |
| `actions/setup-node` | `v4` | `v6` | typecheck-codegen, publish-pypi |
| `actions/setup-python` | `v5` | `v6` | typecheck-codegen, publish-pypi |
| `astral-sh/setup-uv` | `v7` | `v8.2.0` | hub-build, publish-pages, test (×2), sync, publish-pypi |

`cache@v5`, `setup-node@v6`, and `setup-python@v6` are Node 24 runtime bumps — they clear the deprecation warning. Inputs are unchanged across these majors (no inputs for setup-uv; `node-version` / `python-version` unchanged), so these are mechanical, input-compatible bumps.

### Why `setup-uv` is pinned to a full version
From v8 on, `setup-uv` **stopped publishing rolling major/minor tags** (supply-chain hardening — see [their v8.0.0 notes](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0)), so `@v8` no longer resolves. It must be pinned to a full immutable tag; pinned to `v8.2.0` with an inline comment so a future reader doesn't "fix" it back to a major tag.

## Already at latest (left as-is)
`actions/checkout@v6`, `actions/configure-pages@v6`, `actions/upload-pages-artifact@v5`, `actions/deploy-pages@v5`, `peter-evans/create-pull-request@v8`, `pypa/gh-action-pypi-publish@release/v1` (intentional branch ref).

## Validation
All 8 workflow files re-parse as valid YAML after the edits.