### PR TITLE
Add pinned source repositories to version manifests

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -150,6 +150,13 @@ Specifies configuration and available apps for a specific package version.
 - `executables` - Executable validation configuration for CI
   - `required` - Executables that must exist in the container (validated by CI)
   - `ignored` - Executables explicitly excluded from wrapping
+- `sources` - Upstream source repositories used to generate this version's
+  descriptors, pinned to match the container build. Each entry has:
+  - `repo` - Git clone URL (`.git`)
+  - `ref` - Pinned git ref (tag, branch, or commit SHA); `null` = default branch
+  - `role` - `"primary"` (the tool's own source) or `"dependency"` (a supporting
+    repo read for type/output context, e.g. ITK for ANTs)
+  - `note` - Optional rationale for the dependency or ref choice
 - `release_date` - Release date in ISO 8601 format (`"YYYY-MM-DD"`)
 - `deprecated` - Boolean flag indicating deprecated versions
 - `docs` - Version-specific documentation

--- a/schemas/version.schema.json
+++ b/schemas/version.schema.json
@@ -42,6 +42,35 @@
       },
       "additionalProperties": false
     },
+    "sources": {
+      "type": "array",
+      "description": "Upstream source repositories used to generate this version's descriptors, pinned to match the container build.",
+      "items": {
+        "type": "object",
+        "required": ["repo", "role"],
+        "properties": {
+          "repo": {
+            "type": "string",
+            "format": "uri",
+            "description": "Git clone URL (.git)"
+          },
+          "ref": {
+            "type": ["string", "null"],
+            "description": "Pinned git ref (tag, branch, or commit SHA). null means unpinned (clone the default branch)."
+          },
+          "role": {
+            "type": "string",
+            "enum": ["primary", "dependency"],
+            "description": "primary: the tool's own source code. dependency: a supporting repo (e.g. ITK for ANTs) read for type/output context during descriptor generation."
+          },
+          "note": {
+            "type": "string",
+            "description": "Optional rationale: why a dependency is included, or how/why a ref was chosen."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
     "release_date": {
       "type": "string",
       "format": "date",

--- a/src/niwrap/afni/24.2.06/version.json
+++ b/src/niwrap/afni/24.2.06/version.json
@@ -1226,5 +1226,12 @@
       "uber_subject.py",
       "uber_ttest.py"
     ]
-  }
+  },
+  "sources": [
+    {
+      "repo": "https://github.com/afni/afni.git",
+      "ref": "AFNI_24.2.06",
+      "role": "primary"
+    }
+  ]
 }

--- a/src/niwrap/ants/2.5.3/version.json
+++ b/src/niwrap/ants/2.5.3/version.json
@@ -241,5 +241,18 @@
       "waitForSlurmJobs.pl",
       "waitForXGridJobs.pl"
     ]
-  }
+  },
+  "sources": [
+    {
+      "repo": "https://github.com/ANTsX/ANTs.git",
+      "ref": "v2.5.3",
+      "role": "primary"
+    },
+    {
+      "repo": "https://github.com/InsightSoftwareConsortium/ITK.git",
+      "ref": "4535548a8539757c5fe9d81f8de5d804cd0a384f",
+      "role": "dependency",
+      "note": "ITK 5.4 pinned by ANTs v2.5.3 SuperBuild/External_ITKv5.cmake; ANTs CLIs expose ITK filter/IO options"
+    }
+  ]
 }

--- a/src/niwrap/c3d/1.1.0/version.json
+++ b/src/niwrap/c3d/1.1.0/version.json
@@ -17,5 +17,19 @@
     "ignored": [
       "c3d_gui"
     ]
-  }
+  },
+  "sources": [
+    {
+      "repo": "https://github.com/pyushkevich/c3d.git",
+      "ref": "677563203e45889138a5188b82b378c148019353",
+      "role": "primary",
+      "note": "commit bundled as a submodule by ITK-SNAP v3.8.2 (container pyushkevich/itksnap:v3.8.2); no upstream tag for niwrap version 1.1.0"
+    },
+    {
+      "repo": "https://github.com/InsightSoftwareConsortium/ITK.git",
+      "ref": "v4.12.2",
+      "role": "dependency",
+      "note": "ITK version required by ITK-SNAP 3.8.x (Convert3D builds against ITK)"
+    }
+  ]
 }

--- a/src/niwrap/dcm2niix/1.0.20240202/version.json
+++ b/src/niwrap/dcm2niix/1.0.20240202/version.json
@@ -8,5 +8,12 @@
     "required": [
       "dcm2niix"
     ]
-  }
+  },
+  "sources": [
+    {
+      "repo": "https://github.com/rordenlab/dcm2niix.git",
+      "ref": "v1.0.20240202",
+      "role": "primary"
+    }
+  ]
 }

--- a/src/niwrap/fastsurfer/2.3.3/version.json
+++ b/src/niwrap/fastsurfer/2.3.3/version.json
@@ -8,5 +8,12 @@
     "required": [
       "run_fastsurfer.sh"
     ]
-  }
+  },
+  "sources": [
+    {
+      "repo": "https://github.com/Deep-MI/FastSurfer.git",
+      "ref": "v2.3.3",
+      "role": "primary"
+    }
+  ]
 }

--- a/src/niwrap/freesurfer/7.4.1/version.json
+++ b/src/niwrap/freesurfer/7.4.1/version.json
@@ -1577,5 +1577,12 @@
       "unpack_ima1.tcl",
       "unpack_mnc.tcl"
     ]
-  }
+  },
+  "sources": [
+    {
+      "repo": "https://github.com/freesurfer/freesurfer.git",
+      "ref": "v7.4.1",
+      "role": "primary"
+    }
+  ]
 }

--- a/src/niwrap/fsl/6.0.4/version.json
+++ b/src/niwrap/fsl/6.0.4/version.json
@@ -644,5 +644,751 @@
       "tmpnam",
       "xtract_viewer"
     ]
-  }
+  },
+  "sources": [
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/CUDIMOT.git",
+      "ref": "FSL-6-0-1",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/CUDIMOT_models.git",
+      "ref": "c2fe2daec5d96d6f8628fe28acc7fec53f1ecf2e",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/CiftiLib.git",
+      "ref": "807187af7ad35e03d8857f4c4bb6b609abe5082f",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/DIVE.git",
+      "ref": "f75b7e0af12fbeb54e8ad6ff902bbb2370354014",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/ELC.git",
+      "ref": "d05343bc6a83eec9920b4003d14a74b9212b835a",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/FastPDlib.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/FslBuildManifests.git",
+      "ref": "FSL6.0.4",
+      "role": "primary",
+      "note": "best-effort pin: latest FSL6-0-N (N<=4) tag; not part of the FSL6.0.4 source manifest"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/MMORF.git",
+      "ref": "362d89429cce520c919c84d65fb3391e865cb28d",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/MSM.git",
+      "ref": "FSL6-0-0",
+      "role": "primary",
+      "note": "best-effort pin: latest FSL6-0-N (N<=4) tag; not part of the FSL6.0.4 source manifest"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/MVdisc.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/NewNifti.git",
+      "ref": "3.0.5",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/add_module.git",
+      "ref": "aacdb525a201bf88d809e9fc7a9f250bbd1d3427",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/armawrap.git",
+      "ref": "0.4.1",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/avwutils.git",
+      "ref": "2007.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/base.git",
+      "ref": "c7b2ac1ec666b2130029128eded7a1e1158477f5",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/basisfield.git",
+      "ref": "1910.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/baycest.git",
+      "ref": "FSL6-0-1",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/bet-server.git",
+      "ref": "d25e6a7e653d46d3e620ff00f62f559c9f9c7537",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/bet2.git",
+      "ref": "2001.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/bianca.git",
+      "ref": "2005.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/biancaData.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/bint.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/bip.git",
+      "ref": "a01e7b5ed7bda124b8208d663df04a208dd543bb",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/bzqc.git",
+      "ref": "8154c1bba8154836e9472dc6a63a41f4ff53ba5b",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/cluster.git",
+      "ref": "2004.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/conda_vtk_recipe.git",
+      "ref": "3b401a6bd12f5a77110296b2a92a62fbce01f858",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/config.git",
+      "ref": "2006.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/copain.git",
+      "ref": "7253d16442f47c4986104db5a657def34bda2ee4",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/cprob.git",
+      "ref": "2006.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/cudabasisfield.git",
+      "ref": "v1-0-1",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/distbase.git",
+      "ref": "2006.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/docs.git",
+      "ref": "19ee92cb0bd8ffae501004e33adffb45e47b528b",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/dpm.git",
+      "ref": "67536108db30cedb73c6fee4b91600509f0d462d",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/dwssfp.git",
+      "ref": "7b9de183ce86011e1eb56681443abbd2a233c702",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/easyfeat.git",
+      "ref": "0ff31f76cf148218636c5ffa026745be846b72ba",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/eddy.git",
+      "ref": "2007.1",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/eddy_qc.git",
+      "ref": "0ba8a53e8997433210d2c9c54c20720465864c93",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/etc.git",
+      "ref": "1911.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fast4.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fastconfounds.git",
+      "ref": "3c9da4a38ff243ac7803df8f1d49d401e6fecf92",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fdt.git",
+      "ref": "2007.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/feat5.git",
+      "ref": "2007.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/file-tree.git",
+      "ref": "adfc0c815589c488cc7dbc3435fa4b16de55db84",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/file-tree-fsl.git",
+      "ref": "9252a12b49b4722cfbb430a11ec5650de44b59e6",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/film.git",
+      "ref": "2007.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/filmbabe.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/first.git",
+      "ref": "2006.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/first_lib.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fix.git",
+      "ref": "2765c70ced78a663926aecfb60676a1504aec507",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fix_temp_legacy.git",
+      "ref": "3705b2c0996f45e66070a3828a11ca1bfd6ba993",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/flameo.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/flirt.git",
+      "ref": "2004.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fnirt.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fsf2json.git",
+      "ref": "433cd5502b510f33c324041b66362d2950fe0ba3",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fsl-cifti.git",
+      "ref": "9529c02597948f76156419f7cc608f7053290c70",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fsl-gui.git",
+      "ref": "c2962fb461dba09ca517a8fcd3fba606cd888c6a",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fsl-pipe.git",
+      "ref": "395a9add66d172c41e7a1bead5064b84669d1ad1",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fsl_deface.git",
+      "ref": "1.2.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fsl_mrs.git",
+      "ref": "264d1c705863aef946b3d79a69861e3a306cab8b",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fsl_mrs_practicals.git",
+      "ref": "57a0528ca1a5df9ca5ca6f3bb67091880b9d0f07",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fsl_sub.git",
+      "ref": "933a6e3dfb97840f3c44f10305eb3a7148c08fa4",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fsl_sub_plugin_sge.git",
+      "ref": "ac85feefa33f3413e185132a92011d9e5411a356",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fsl_sub_plugin_slurm.git",
+      "ref": "f10b7f06af37c31749e4cfd0eeaad14685cc29d7",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fslgui.git",
+      "ref": "39ec90218aaac78c5f9a0e0ff821484ee0b8096b",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fslio.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fsljs.git",
+      "ref": "fd5318101b6b80583ff64ca8081c8112f33af096",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fslnets.git",
+      "ref": "b4de9f36ba130c50f22b0fc678264f4c4cfe70a6",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fslpy.git",
+      "ref": "d8264aefdc29560c69794db9f3784b656488de06",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fslsurface.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fslvbm.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fslview.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fslvtkio.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/fugue.git",
+      "ref": "1912.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/funpack.git",
+      "ref": "2ea26548b247b3a67505dd34f555a76424bc45bb",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/funpack-fmrib-config.git",
+      "ref": "ccc3f70428049ceefb169fa60821d257246cb486",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/get_standard.git",
+      "ref": "e771f6bd7c046b56fb9eaae9d3dc9a3e10c14e2c",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/giftiio.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/gps.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/gradunwarp.git",
+      "ref": "6ddc6e28481734bddf54e37e4a7f600902ad1672",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/installer.git",
+      "ref": "ac694dbf71ed7c9fccdd44b814b6707156fc1d5e",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/lesions.git",
+      "ref": "1909.1",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/libgdc.git",
+      "ref": "2006.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/libmeshutils.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/libvis.git",
+      "ref": "1909.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/load_dicom.git",
+      "ref": "982909d223eca07358487ac744b46308872edb88",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/load_varian.git",
+      "ref": "3ebc1c8a01cbf836b247480ca0cce232a488b8c1",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/mcflirt.git",
+      "ref": "FSL6-0-1",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/melodic.git",
+      "ref": "2005.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/melview.git",
+      "ref": "93f77efcea0f90e6a38512620fc4e987f9004b7f",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/meshclass.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/misc_c.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/misc_scripts.git",
+      "ref": "2004.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/misc_tcl.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/miscmaths.git",
+      "ref": "2007.1",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/miscvis.git",
+      "ref": "2007.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/mist.git",
+      "ref": "1904.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/mm.git",
+      "ref": "1909.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/move_fsl.git",
+      "ref": "3a1e3ce7e079ca5a36d894af350bf46f1820f46b",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/newimage.git",
+      "ref": "2006.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/newmesh.git",
+      "ref": "1904.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/newran.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/openneuro-dl.git",
+      "ref": "1e5e584fbf06537815fbf63f5ad3fc80476997aa",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/possum.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/post_install.git",
+      "ref": "2007.3",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/ptx2.git",
+      "ref": "2001.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/ptx2_gpu.git",
+      "ref": "25e4488af24c3dabc74c2d07fa0f96ae24317b18",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/pyconf.git",
+      "ref": "eb9704444b900d74171f7455a8a91842557905cd",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/pydr.git",
+      "ref": "a77412d965dd01119c4d2a0b6765ccff643751e6",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/pyfeeds.git",
+      "ref": "114e35aff4f6f5280eabc6c42a964a452ef6c661",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/pyfeeds-tests.git",
+      "ref": "547a0b3e6a8ef04c8beb77d96fc588eece69ea36",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/pyfix.git",
+      "ref": "4fd579aed58dbb4645e12ff6cddccc99e93d4329",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/pytreat-practicals-2018.git",
+      "ref": "0f02f34f0df2cb65fab4ae83049b2f30407559f0",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/pytreat-practicals-2020.git",
+      "ref": "15d75bb584b2afcdc4a724622f2d8afd6c049601",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/qboot.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/randomise.git",
+      "ref": "FSL6-0-2",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/relax.git",
+      "ref": "685d981a9b21ca2e6a893f0133a98eda734a8bf3",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/sgeutils.git",
+      "ref": "1904.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/shapeModel.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/siena.git",
+      "ref": "2006.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/slicetimer.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/strokeseg.git",
+      "ref": "26472b550f12960d11e66bfeb360cefc9d2a719b",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/susan.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/swe.git",
+      "ref": "v1.0.3",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/tbss.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/tirl.git",
+      "ref": "c23bce89a404e40117cd479251ad1afbc2bc4fd4",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/tissue.git",
+      "ref": "def323d7ae53d0239dd760a9b6ad3aec8aa5f8c6",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/topup.git",
+      "ref": "1911.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/ukbparse.git",
+      "ref": "3709ebbb6bcba6bea83b3a5cb41b4caed968f020",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/utils.git",
+      "ref": "2007.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/vtk.git",
+      "ref": "92dbc7a5ba7974501d6f288caf6dfb660a8b1cdc",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/warpfns.git",
+      "ref": "1912.0",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/win-pytreat.git",
+      "ref": "69add00be6a57792a31889a3b5f09c7c8031ac6c",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/winpack.git",
+      "ref": "a9f46841f8e5da9eb5c93b5d415ec30d0f2159f8",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/wire.git",
+      "ref": "49bfc2fb89b71475a043430db2e93fd2636f666b",
+      "role": "primary",
+      "note": "best-effort pin: frozen default-branch HEAD; not in the FSL6.0.4 source manifest and has no FSL6-0-<=4 tag"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/xtract.git",
+      "ref": "1.4.1",
+      "role": "primary"
+    },
+    {
+      "repo": "https://git.fmrib.ox.ac.uk/fsl/znzlib.git",
+      "ref": "FSL6-0-0",
+      "role": "primary"
+    }
+  ]
 }

--- a/src/niwrap/greedy/1.0.1/version.json
+++ b/src/niwrap/greedy/1.0.1/version.json
@@ -8,5 +8,19 @@
     "required": [
       "greedy"
     ]
-  }
+  },
+  "sources": [
+    {
+      "repo": "https://github.com/pyushkevich/greedy.git",
+      "ref": "3ed5a0dc480bf0ca3f850e6783208bae3aef570c",
+      "role": "primary",
+      "note": "commit bundled as a submodule by ITK-SNAP v3.8.2 (container pyushkevich/itksnap:v3.8.2); no upstream tag for niwrap version 1.0.1"
+    },
+    {
+      "repo": "https://github.com/InsightSoftwareConsortium/ITK.git",
+      "ref": "v4.12.2",
+      "role": "dependency",
+      "note": "ITK version required by ITK-SNAP 3.8.x (greedy builds against ITK)"
+    }
+  ]
 }

--- a/src/niwrap/mrtrix/3.0.4/version.json
+++ b/src/niwrap/mrtrix/3.0.4/version.json
@@ -254,5 +254,12 @@
       "mrview",
       "shview"
     ]
-  }
+  },
+  "sources": [
+    {
+      "repo": "https://github.com/MRtrix3/mrtrix3.git",
+      "ref": "3.0.4",
+      "role": "primary"
+    }
+  ]
 }

--- a/src/niwrap/mrtrix3tissue/5.2.8/version.json
+++ b/src/niwrap/mrtrix3tissue/5.2.8/version.json
@@ -8,5 +8,12 @@
     "required": [
       "ss3t_csd_beta1"
     ]
-  }
+  },
+  "sources": [
+    {
+      "repo": "https://github.com/3Tissue/MRtrix3Tissue.git",
+      "ref": "3Tissue_v5.2.8",
+      "role": "primary"
+    }
+  ]
 }

--- a/src/niwrap/niftyreg/1.4.0/version.json
+++ b/src/niwrap/niftyreg/1.4.0/version.json
@@ -20,5 +20,13 @@
       "reg_transform",
       "reg_aladin"
     ]
-  }
+  },
+  "sources": [
+    {
+      "repo": "https://github.com/KCL-BMEIS/niftyreg.git",
+      "ref": "8ad2f11507ddedb09ed74a9bd97377b70532ee75",
+      "role": "primary",
+      "note": "commit built by the Neurodesk vnmd/niftyreg_1.4.0 container (neurocontainers recipe); no upstream v1.4.0 tag"
+    }
+  ]
 }

--- a/src/niwrap/workbench/2.1.0/version.json
+++ b/src/niwrap/workbench/2.1.0/version.json
@@ -213,5 +213,12 @@
     "ignored": [
       "wb_view"
     ]
-  }
+  },
+  "sources": [
+    {
+      "repo": "https://github.com/Washington-University/workbench.git",
+      "ref": "v2.1.0",
+      "role": "primary"
+    }
+  ]
 }


### PR DESCRIPTION
## What

Adds a `sources` array to the `version.json` schema and populates it for all 12 packages. Each entry pins an upstream git ref (tag, branch, or commit SHA) that matches the version's **container build**, making descriptor generation reproducible.

```json
"sources": [
  {"repo": "https://github.com/ANTsX/ANTs.git", "ref": "v2.5.3", "role": "primary"},
  {"repo": "https://github.com/InsightSoftwareConsortium/ITK.git",
   "ref": "4535548a…", "role": "dependency", "note": "ITK 5.4 pinned by ANTs SuperBuild"}
]
```

## Why

The source registry previously lived in `styx-agent/scripts/repos.json` as an unpinned, drift-prone list. NiWrap already pins the container per version, so the source refs belong here next to it — one source of truth, and reproducible regeneration of any version's descriptors.

## How the pins were determined

- **8 packages** pin to verified upstream tags (afni, ants, dcm2niix, fastsurfer, freesurfer, mrtrix, mrtrix3tissue, workbench).
- **c3d / greedy / niftyreg** pin exact commits — their NiWrap versions are packaging labels, not upstream tags (traced via ITK-SNAP submodules and the Neurodesk recipe).
- **Dependencies**: ITK for ants (SuperBuild pin), c3d, greedy (ITK-SNAP `v4.12.2`).
- **FSL** (136 component repos): 72 pinned authoritatively from `FslBuildManifests` @ tag `FSL6.0.4`; the other 64 aren't in that source manifest (GUIs, tutorials, packaging, separately-distributed) so they use best-effort reproducible pins — 62 frozen default-branch HEAD SHAs + 2 `FSL6-0-<=4` tags — each annotated in `note`.

All 12 manifests validate against the updated schema (`jsonschema`).

## Companion PR

styx-agent reads these manifests instead of its own registry: https://github.com/styx-api/styx-agent/pull/1