### PR TITLE
feat(metadata): add neuroimaging glossary to published catalog

### DIFF
--- a/.github/workflows/validate-schemas.yml
+++ b/.github/workflows/validate-schemas.yml
@@ -64,7 +64,7 @@ jobs:
             // Extract expected name from path
             const parts = file.split('/');
             const jsonFile = parts[parts.length - 1];
-            const expectedName = jsonFile === 'projects.json' ? null : parts[parts.length - 2];
+            const expectedName = ['projects.json', 'glossary.json'].includes(jsonFile) ? null : parts[parts.length - 2];
             
             if (expectedName && data.name !== expectedName) {
               err(`Name mismatch in ${file}: "${data.name}" vs "${expectedName}"`, file);

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,12 @@
     },
     {
       "fileMatch": [
+        "src/*/glossary.json"
+      ],
+      "url": "/schemas/glossary.schema.json"
+    },
+    {
+      "fileMatch": [
         "src/*/*/package.json"
       ],
       "url": "/schemas/package.schema.json"

--- a/schemas/glossary.schema.json
+++ b/schemas/glossary.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://niwrap.org/schemas/glossary.schema.json",
+  "title": "NiWrap Glossary Schema",
+  "description": "Neuroimaging terminology glossary: abbreviations and terms paired with their expanded names and short definitions. Front-ends (the hub, the docs site) match these terms in tool documentation to surface inline definitions.",
+  "type": "object",
+  "required": ["entries"],
+  "properties": {
+    "entries": {
+      "type": "array",
+      "description": "Glossary entries.",
+      "items": {
+        "type": "object",
+        "required": ["terms", "title", "description"],
+        "properties": {
+          "terms": {
+            "type": "array",
+            "description": "Exact, case-sensitive spellings that should match in text (e.g. ['ANTs', 'ANTS']). Case sensitivity keeps common English words from matching unless written in their acronym form.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          },
+          "title": {
+            "type": "string",
+            "description": "Canonical or expanded name of the term."
+          },
+          "description": {
+            "type": "string",
+            "description": "Short, one-line definition."
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/niwrap/glossary.json
+++ b/src/niwrap/glossary.json
@@ -1,0 +1,1068 @@
+{
+  "entries": [
+    {
+      "terms": [
+        "FreeSurfer"
+      ],
+      "title": "FreeSurfer",
+      "description": "Software suite for processing and analyzing brain MRI images, including cortical surface reconstruction."
+    },
+    {
+      "terms": [
+        "AFNI",
+        "afni"
+      ],
+      "title": "Analysis of Functional NeuroImages",
+      "description": "A software suite for processing and analyzing fMRI data."
+    },
+    {
+      "terms": [
+        "ANTs",
+        "ANTS"
+      ],
+      "title": "Advanced Normalization Tools",
+      "description": "A software suite for image registration and segmentation."
+    },
+    {
+      "terms": [
+        "FSL"
+      ],
+      "title": "FMRIB Software Library",
+      "description": "A comprehensive library of neuroimaging analysis tools."
+    },
+    {
+      "terms": [
+        "SPM"
+      ],
+      "title": "Statistical Parametric Mapping",
+      "description": "A software package for analyzing brain imaging data."
+    },
+    {
+      "terms": [
+        "MRtrix3"
+      ],
+      "title": "MRtrix3",
+      "description": "A software suite for diffusion MRI analysis including tractography, fixel-based analysis, and connectivity."
+    },
+    {
+      "terms": [
+        "MRtrix"
+      ],
+      "title": "MRtrix",
+      "description": "A software suite for advanced diffusion MRI processing and fiber tractography."
+    },
+    {
+      "terms": [
+        "ITK"
+      ],
+      "title": "Insight Toolkit",
+      "description": "An open-source library for image segmentation and registration used by many neuroimaging tools."
+    },
+    {
+      "terms": [
+        "VTK"
+      ],
+      "title": "Visualization Toolkit",
+      "description": "An open-source library for 3D computer graphics, image processing, and visualization."
+    },
+    {
+      "terms": [
+        "FastSurfer"
+      ],
+      "title": "FastSurfer",
+      "description": "A deep learning-based alternative to FreeSurfer for fast brain segmentation and surface reconstruction."
+    },
+    {
+      "terms": [
+        "dcm2niix"
+      ],
+      "title": "dcm2niix",
+      "description": "A tool for converting DICOM and PAR/REC images to NIfTI format."
+    },
+    {
+      "terms": [
+        "Convert3D",
+        "C3D",
+        "c3d"
+      ],
+      "title": "Convert3D",
+      "description": "A command-line tool for converting and processing 3D medical images."
+    },
+    {
+      "terms": [
+        "NIfTyReg",
+        "niftyreg"
+      ],
+      "title": "NIfTyReg",
+      "description": "A software package for efficient medical image registration."
+    },
+    {
+      "terms": [
+        "TORTOISE"
+      ],
+      "title": "TORTOISE",
+      "description": "Tolerably Obsessive Registration and Tensor Optimization Indolent Software Ensemble for diffusion MRI processing."
+    },
+    {
+      "terms": [
+        "HCP"
+      ],
+      "title": "Human Connectome Project",
+      "description": "A large-scale project mapping neural connections in the human brain, with associated pipelines and data formats."
+    },
+    {
+      "terms": [
+        "SUMA"
+      ],
+      "title": "Surface Mapper",
+      "description": "An AFNI program for surface-based brain visualization and analysis."
+    },
+    {
+      "terms": [
+        "SynthSeg"
+      ],
+      "title": "SynthSeg",
+      "description": "A FreeSurfer deep learning tool for brain segmentation that works on any MRI contrast without retraining."
+    },
+    {
+      "terms": [
+        "SynthSR"
+      ],
+      "title": "SynthSR",
+      "description": "A FreeSurfer deep learning tool for super-resolution and contrast synthesis of brain MRI."
+    },
+    {
+      "terms": [
+        "SynthStrip"
+      ],
+      "title": "SynthStrip",
+      "description": "A FreeSurfer deep learning tool for robust skull stripping across MRI contrasts and ages."
+    },
+    {
+      "terms": [
+        "Connectome Workbench"
+      ],
+      "title": "Connectome Workbench",
+      "description": "A visualization and analysis tool for surface and volume neuroimaging data, especially HCP-style CIFTI files."
+    },
+    {
+      "terms": [
+        "BEDPOSTX"
+      ],
+      "title": "Bayesian Estimation of Diffusion Parameters Obtained using Sampling Techniques",
+      "description": "An FSL tool for modeling crossing fibers in diffusion data."
+    },
+    {
+      "terms": [
+        "PROBTRACKX"
+      ],
+      "title": "Probabilistic Tractography",
+      "description": "An FSL tool for probabilistic fiber tracking from diffusion data."
+    },
+    {
+      "terms": [
+        "MELODIC"
+      ],
+      "title": "Multivariate Exploratory Linear Optimized Decomposition into Independent Components",
+      "description": "An FSL tool for ICA-based analysis."
+    },
+    {
+      "terms": [
+        "MCFLIRT"
+      ],
+      "title": "Motion Correction FLIRT",
+      "description": "An FSL tool for intra-modal motion correction of fMRI time series."
+    },
+    {
+      "terms": [
+        "SIENAX"
+      ],
+      "title": "Structural Image Evaluation using Normalization of Atrophy (Cross-sectional)",
+      "description": "An FSL tool for cross-sectional brain volume estimation normalized for head size."
+    },
+    {
+      "terms": [
+        "BIANCA"
+      ],
+      "title": "Brain Intensity AbNormality Classification Algorithm",
+      "description": "An FSL tool for detecting white matter hyperintensities."
+    },
+    {
+      "terms": [
+        "SIENA"
+      ],
+      "title": "Structural Image Evaluation using Normalization of Atrophy",
+      "description": "An FSL tool for longitudinal brain atrophy measurement between two time points."
+    },
+    {
+      "terms": [
+        "TOPUP"
+      ],
+      "title": "TOPUP",
+      "description": "An FSL tool for estimating and correcting susceptibility-induced distortions in EPI data."
+    },
+    {
+      "terms": [
+        "FLIRT"
+      ],
+      "title": "FMRIB's Linear Image Registration Tool",
+      "description": "An FSL tool for affine (linear) image registration."
+    },
+    {
+      "terms": [
+        "FNIRT"
+      ],
+      "title": "FMRIB's Nonlinear Image Registration Tool",
+      "description": "An FSL tool for nonlinear (warp) image registration."
+    },
+    {
+      "terms": [
+        "FIRST"
+      ],
+      "title": "FMRIB's Integrated Registration and Segmentation Tool",
+      "description": "An FSL tool for subcortical structure segmentation."
+    },
+    {
+      "terms": [
+        "SUSAN"
+      ],
+      "title": "Smallest Univalue Segment Assimilating Nucleus",
+      "description": "An FSL noise reduction algorithm that preserves edges during smoothing."
+    },
+    {
+      "terms": [
+        "PRELUDE"
+      ],
+      "title": "Phase Region Expanding Labeller for Unwrapping Discrete Estimates",
+      "description": "An FSL tool for 3D phase unwrapping."
+    },
+    {
+      "terms": [
+        "FUGUE"
+      ],
+      "title": "FMRIB Utility for Geometrically Unwarping EPIs",
+      "description": "An FSL tool for EPI distortion correction using field maps."
+    },
+    {
+      "terms": [
+        "EDDY"
+      ],
+      "title": "EDDY Current Correction",
+      "description": "An FSL tool for correcting eddy current distortions and subject movement in diffusion data."
+    },
+    {
+      "terms": [
+        "TBSS"
+      ],
+      "title": "Tract-Based Spatial Statistics",
+      "description": "An FSL tool for voxelwise analysis of diffusion data along white matter tracts."
+    },
+    {
+      "terms": [
+        "FEAT"
+      ],
+      "title": "FMRIB's Expert Analysis Tool",
+      "description": "An FSL tool for model-based fMRI statistical analysis."
+    },
+    {
+      "terms": [
+        "FAST"
+      ],
+      "title": "FMRIB's Automated Segmentation Tool",
+      "description": "An FSL tool for brain tissue segmentation."
+    },
+    {
+      "terms": [
+        "BET"
+      ],
+      "title": "Brain Extraction Tool",
+      "description": "An FSL tool for removing non-brain tissue from MRI images."
+    },
+    {
+      "terms": [
+        "RANDOMISE"
+      ],
+      "title": "RANDOMISE",
+      "description": "An FSL tool for non-parametric permutation inference on neuroimaging data."
+    },
+    {
+      "terms": [
+        "PALM"
+      ],
+      "title": "Permutation Analysis of Linear Models",
+      "description": "A tool for non-parametric inference using sign-flipping and permutation tests."
+    },
+    {
+      "terms": [
+        "COPE"
+      ],
+      "title": "Contrast of Parameter Estimates",
+      "description": "A statistical map representing a weighted combination of parameter estimates in GLM analysis."
+    },
+    {
+      "terms": [
+        "VARCOPE"
+      ],
+      "title": "Variance of Contrast of Parameter Estimates",
+      "description": "The estimated variance of a COPE, used for higher-level mixed-effects analysis."
+    },
+    {
+      "terms": [
+        "FLAME"
+      ],
+      "title": "FMRIB's Local Analysis of Mixed Effects",
+      "description": "An FSL method for mixed-effects group-level fMRI analysis."
+    },
+    {
+      "terms": [
+        "NIfTI",
+        "NIFTI",
+        "Nifti",
+        "nifti"
+      ],
+      "title": "Neuroimaging Informatics Technology Initiative",
+      "description": "Standard file format (.nii) for storing brain imaging data."
+    },
+    {
+      "terms": [
+        "DICOM",
+        "Dicom"
+      ],
+      "title": "Digital Imaging and Communications in Medicine",
+      "description": "Standard format for medical imaging data from scanners."
+    },
+    {
+      "terms": [
+        "CIFTI"
+      ],
+      "title": "Connectivity Informatics Technology Initiative",
+      "description": "A file format combining surface and volume neuroimaging data."
+    },
+    {
+      "terms": [
+        "GIFTI"
+      ],
+      "title": "Geometry Informatics Technology Initiative",
+      "description": "A file format for brain surface geometry data."
+    },
+    {
+      "terms": [
+        "MINC"
+      ],
+      "title": "Medical Imaging NetCDF",
+      "description": "A file format for medical imaging data used in neuroimaging research."
+    },
+    {
+      "terms": [
+        "MGH"
+      ],
+      "title": "Massachusetts General Hospital Format",
+      "description": "A neuroimaging file format used by FreeSurfer."
+    },
+    {
+      "terms": [
+        "MGZ"
+      ],
+      "title": "Compressed MGH Format",
+      "description": "A gzip-compressed variant of the MGH file format used by FreeSurfer."
+    },
+    {
+      "terms": [
+        "BIDS"
+      ],
+      "title": "Brain Imaging Data Structure",
+      "description": "A standard for organizing and describing neuroimaging datasets."
+    },
+    {
+      "terms": [
+        "MIF"
+      ],
+      "title": "MRtrix Image Format",
+      "description": "The native image file format used by MRtrix3 for storing neuroimaging data with header metadata."
+    },
+    {
+      "terms": [
+        "TRK"
+      ],
+      "title": "TrackVis Track Format",
+      "description": "A binary file format for storing streamline tractography results."
+    },
+    {
+      "terms": [
+        "STL"
+      ],
+      "title": "Stereolithography Format",
+      "description": "A surface mesh file format used for 3D surface representations of brain structures."
+    },
+    {
+      "terms": [
+        "MPRAGE"
+      ],
+      "title": "Magnetization Prepared Rapid Gradient Echo",
+      "description": "A T1-weighted MRI sequence commonly used for high-resolution structural brain imaging."
+    },
+    {
+      "terms": [
+        "FLAIR"
+      ],
+      "title": "Fluid-Attenuated Inversion Recovery",
+      "description": "An MRI sequence that suppresses CSF signal to reveal lesions."
+    },
+    {
+      "terms": [
+        "rsfMRI",
+        "rs-fMRI"
+      ],
+      "title": "Resting-State Functional MRI",
+      "description": "Measures spontaneous brain activity when a subject is at rest."
+    },
+    {
+      "terms": [
+        "fMRI",
+        "FMRI"
+      ],
+      "title": "Functional Magnetic Resonance Imaging",
+      "description": "Measures brain activity by detecting changes in blood oxygenation."
+    },
+    {
+      "terms": [
+        "BOLD"
+      ],
+      "title": "Blood-Oxygen-Level-Dependent",
+      "description": "The MRI contrast mechanism underlying fMRI."
+    },
+    {
+      "terms": [
+        "SWI"
+      ],
+      "title": "Susceptibility Weighted Imaging",
+      "description": "An MRI technique sensitive to magnetic susceptibility differences between tissues."
+    },
+    {
+      "terms": [
+        "DTI"
+      ],
+      "title": "Diffusion Tensor Imaging",
+      "description": "An MRI technique that maps white matter tract orientation using water diffusion."
+    },
+    {
+      "terms": [
+        "DWI"
+      ],
+      "title": "Diffusion-Weighted Imaging",
+      "description": "An MRI technique sensitive to the diffusion of water molecules in tissue."
+    },
+    {
+      "terms": [
+        "EPI"
+      ],
+      "title": "Echo-Planar Imaging",
+      "description": "A fast MRI acquisition method commonly used in fMRI and diffusion imaging."
+    },
+    {
+      "terms": [
+        "MRI"
+      ],
+      "title": "Magnetic Resonance Imaging",
+      "description": "A non-invasive imaging technique using magnetic fields and radio waves."
+    },
+    {
+      "terms": [
+        "PET"
+      ],
+      "title": "Positron Emission Tomography",
+      "description": "A nuclear imaging technique that measures metabolic processes."
+    },
+    {
+      "terms": [
+        "MEG"
+      ],
+      "title": "Magnetoencephalography",
+      "description": "A technique for mapping brain activity by recording magnetic fields."
+    },
+    {
+      "terms": [
+        "EEG"
+      ],
+      "title": "Electroencephalography",
+      "description": "A technique for recording electrical activity of the brain."
+    },
+    {
+      "terms": [
+        "FWHM",
+        "fwhm"
+      ],
+      "title": "Full Width at Half Maximum",
+      "description": "A measure of spatial smoothing kernel size."
+    },
+    {
+      "terms": [
+        "FOV"
+      ],
+      "title": "Field of View",
+      "description": "The extent of the area captured by the MRI scanner."
+    },
+    {
+      "terms": [
+        "TR"
+      ],
+      "title": "Repetition Time",
+      "description": "The time interval between successive RF excitation pulses in an MRI sequence."
+    },
+    {
+      "terms": [
+        "TE"
+      ],
+      "title": "Echo Time",
+      "description": "The time between RF excitation and signal measurement in an MRI sequence."
+    },
+    {
+      "terms": [
+        "B0"
+      ],
+      "title": "B0 Field",
+      "description": "The main static magnetic field of an MRI scanner."
+    },
+    {
+      "terms": [
+        "RF"
+      ],
+      "title": "Radio Frequency",
+      "description": "Electromagnetic pulses used to excite hydrogen nuclei in MRI."
+    },
+    {
+      "terms": [
+        "PD"
+      ],
+      "title": "Proton Density",
+      "description": "An MRI contrast reflecting the concentration of hydrogen protons in tissue."
+    },
+    {
+      "terms": [
+        "PE"
+      ],
+      "title": "Phase Encoding",
+      "description": "The MRI gradient direction along which spatial position is encoded by phase shifts."
+    },
+    {
+      "terms": [
+        "MT"
+      ],
+      "title": "Magnetization Transfer",
+      "description": "An MRI technique that generates contrast based on interactions between free and bound water protons."
+    },
+    {
+      "terms": [
+        "T1w"
+      ],
+      "title": "T1-Weighted",
+      "description": "An MRI contrast where tissues with short T1 relaxation times (e.g. white matter) appear bright."
+    },
+    {
+      "terms": [
+        "T2w"
+      ],
+      "title": "T2-Weighted",
+      "description": "An MRI contrast where tissues with long T2 relaxation times (e.g. CSF) appear bright."
+    },
+    {
+      "terms": [
+        "T1"
+      ],
+      "title": "T1-Weighted",
+      "description": "An MRI contrast where tissues with short T1 relaxation times (e.g. white matter) appear bright."
+    },
+    {
+      "terms": [
+        "T2"
+      ],
+      "title": "T2-Weighted",
+      "description": "An MRI contrast where tissues with long T2 relaxation times (e.g. CSF) appear bright."
+    },
+    {
+      "terms": [
+        "fixel"
+      ],
+      "title": "Fixel",
+      "description": "A specific fiber population within a single voxel, used in fixel-based analysis to study individual fiber bundles."
+    },
+    {
+      "terms": [
+        "ACT"
+      ],
+      "title": "Anatomically-Constrained Tractography",
+      "description": "A tractography framework that uses tissue segmentation to improve biological plausibility of reconstructed tracts."
+    },
+    {
+      "terms": [
+        "AFD"
+      ],
+      "title": "Apparent Fiber Density",
+      "description": "A fixel-based measure of the density of a specific fiber population within a voxel."
+    },
+    {
+      "terms": [
+        "SH"
+      ],
+      "title": "Spherical Harmonics",
+      "description": "A mathematical basis for representing functions on a sphere, used to model diffusion orientation distributions."
+    },
+    {
+      "terms": [
+        "CSD"
+      ],
+      "title": "Constrained Spherical Deconvolution",
+      "description": "A method for estimating fiber orientation distributions from diffusion data."
+    },
+    {
+      "terms": [
+        "FOD",
+        "fODF"
+      ],
+      "title": "Fiber Orientation Distribution",
+      "description": "A function describing the distribution of fiber orientations within a voxel."
+    },
+    {
+      "terms": [
+        "ODF"
+      ],
+      "title": "Orientation Distribution Function",
+      "description": "A function describing the probability of diffusion in each direction within a voxel."
+    },
+    {
+      "terms": [
+        "GFA"
+      ],
+      "title": "Generalized Fractional Anisotropy",
+      "description": "A diffusion anisotropy measure derived from the ODF, generalizing FA beyond the tensor model."
+    },
+    {
+      "terms": [
+        "bval"
+      ],
+      "title": "b-value File",
+      "description": "A text file listing diffusion weighting strengths for each volume in a DWI acquisition."
+    },
+    {
+      "terms": [
+        "bvec"
+      ],
+      "title": "b-vector File",
+      "description": "A text file listing diffusion gradient directions for each volume in a DWI acquisition."
+    },
+    {
+      "terms": [
+        "FA"
+      ],
+      "title": "Fractional Anisotropy",
+      "description": "A DTI-derived measure of white matter microstructural integrity (0 = isotropic, 1 = anisotropic)."
+    },
+    {
+      "terms": [
+        "MD"
+      ],
+      "title": "Mean Diffusivity",
+      "description": "A DTI-derived measure of the average rate of water diffusion in tissue."
+    },
+    {
+      "terms": [
+        "AD"
+      ],
+      "title": "Axial Diffusivity",
+      "description": "A DTI-derived measure of water diffusion along the principal fiber direction."
+    },
+    {
+      "terms": [
+        "RD"
+      ],
+      "title": "Radial Diffusivity",
+      "description": "A DTI-derived measure of water diffusion perpendicular to the principal fiber direction."
+    },
+    {
+      "terms": [
+        "GM"
+      ],
+      "title": "Gray Matter",
+      "description": "Brain tissue containing neuronal cell bodies, found in the cortex and subcortical nuclei."
+    },
+    {
+      "terms": [
+        "WM"
+      ],
+      "title": "White Matter",
+      "description": "Brain tissue containing myelinated axons that connect brain regions."
+    },
+    {
+      "terms": [
+        "CSF"
+      ],
+      "title": "Cerebrospinal Fluid",
+      "description": "The clear fluid surrounding the brain and spinal cord."
+    },
+    {
+      "terms": [
+        "WMH"
+      ],
+      "title": "White Matter Hyperintensity",
+      "description": "Bright regions on FLAIR MRI indicating white matter damage, often associated with aging or vascular disease."
+    },
+    {
+      "terms": [
+        "ICA"
+      ],
+      "title": "Independent Component Analysis",
+      "description": "A method for separating a signal into independent sub-components."
+    },
+    {
+      "terms": [
+        "PCA"
+      ],
+      "title": "Principal Component Analysis",
+      "description": "A dimensionality reduction technique."
+    },
+    {
+      "terms": [
+        "GLM"
+      ],
+      "title": "General Linear Model",
+      "description": "A statistical framework used for fMRI activation analysis."
+    },
+    {
+      "terms": [
+        "HRF"
+      ],
+      "title": "Hemodynamic Response Function",
+      "description": "Models the blood flow response to neural activity in fMRI."
+    },
+    {
+      "terms": [
+        "ICC"
+      ],
+      "title": "Intraclass Correlation Coefficient",
+      "description": "A measure of measurement reliability or agreement between raters."
+    },
+    {
+      "terms": [
+        "ANOVA"
+      ],
+      "title": "Analysis of Variance",
+      "description": "A statistical test for comparing means across multiple groups."
+    },
+    {
+      "terms": [
+        "REML"
+      ],
+      "title": "Restricted Maximum Likelihood",
+      "description": "An estimation method for variance components that accounts for fixed effects in mixed models."
+    },
+    {
+      "terms": [
+        "MCMC"
+      ],
+      "title": "Markov Chain Monte Carlo",
+      "description": "A class of sampling algorithms for estimating posterior distributions in Bayesian analysis."
+    },
+    {
+      "terms": [
+        "SVD"
+      ],
+      "title": "Singular Value Decomposition",
+      "description": "A matrix factorization method used for dimensionality reduction and noise filtering."
+    },
+    {
+      "terms": [
+        "DOF",
+        "dof"
+      ],
+      "title": "Degrees of Freedom",
+      "description": "The number of independent values free to vary in a statistical model."
+    },
+    {
+      "terms": [
+        "RMS"
+      ],
+      "title": "Root Mean Square",
+      "description": "A statistical measure of the magnitude of a varying quantity, often used for motion estimates."
+    },
+    {
+      "terms": [
+        "MSE"
+      ],
+      "title": "Mean Squared Error",
+      "description": "The average of the squared differences between predicted and observed values."
+    },
+    {
+      "terms": [
+        "SEM"
+      ],
+      "title": "Standard Error of the Mean",
+      "description": "A measure of how precisely the sample mean estimates the population mean."
+    },
+    {
+      "terms": [
+        "FPR"
+      ],
+      "title": "False Positive Rate",
+      "description": "The proportion of negative cases incorrectly classified as positive."
+    },
+    {
+      "terms": [
+        "ROC"
+      ],
+      "title": "Receiver Operating Characteristic",
+      "description": "A curve plotting true positive rate against false positive rate across classification thresholds."
+    },
+    {
+      "terms": [
+        "MI"
+      ],
+      "title": "Mutual Information",
+      "description": "A similarity metric for image registration that measures shared information between two images."
+    },
+    {
+      "terms": [
+        "NMI"
+      ],
+      "title": "Normalized Mutual Information",
+      "description": "A normalized variant of mutual information commonly used as a cost function in inter-modal registration."
+    },
+    {
+      "terms": [
+        "SSD"
+      ],
+      "title": "Sum of Squared Differences",
+      "description": "A similarity metric for image registration that sums pixelwise intensity differences squared."
+    },
+    {
+      "terms": [
+        "TSNR"
+      ],
+      "title": "Temporal Signal-to-Noise Ratio",
+      "description": "The ratio of mean signal to temporal standard deviation, a measure of fMRI data quality."
+    },
+    {
+      "terms": [
+        "DVARS"
+      ],
+      "title": "Derivative of RMS Variance",
+      "description": "A measure of the rate of change of BOLD signal across the brain at each time point."
+    },
+    {
+      "terms": [
+        "FD"
+      ],
+      "title": "Framewise Displacement",
+      "description": "A scalar measure of head motion between consecutive fMRI volumes."
+    },
+    {
+      "terms": [
+        "TFCE"
+      ],
+      "title": "Threshold-Free Cluster Enhancement",
+      "description": "A statistical method that avoids arbitrary cluster-forming thresholds."
+    },
+    {
+      "terms": [
+        "FDR"
+      ],
+      "title": "False Discovery Rate",
+      "description": "A statistical method for correcting multiple comparisons in neuroimaging."
+    },
+    {
+      "terms": [
+        "FWE"
+      ],
+      "title": "Family-Wise Error",
+      "description": "A method for controlling the probability of any false positive across all tests."
+    },
+    {
+      "terms": [
+        "SNR"
+      ],
+      "title": "Signal-to-Noise Ratio",
+      "description": "A measure of signal strength relative to background noise."
+    },
+    {
+      "terms": [
+        "CNR"
+      ],
+      "title": "Contrast-to-Noise Ratio",
+      "description": "A measure of contrast between tissues relative to noise."
+    },
+    {
+      "terms": [
+        "ROI"
+      ],
+      "title": "Region of Interest",
+      "description": "A specific brain area selected for targeted analysis."
+    },
+    {
+      "terms": [
+        "VOI"
+      ],
+      "title": "Volume of Interest",
+      "description": "A 3D region selected for analysis, similar to ROI."
+    },
+    {
+      "terms": [
+        "VBM"
+      ],
+      "title": "Voxel-Based Morphometry",
+      "description": "A technique for analyzing local differences in brain tissue composition."
+    },
+    {
+      "terms": [
+        "CBF"
+      ],
+      "title": "Cerebral Blood Flow",
+      "description": "A measure of blood supply to brain tissue."
+    },
+    {
+      "terms": [
+        "ASL"
+      ],
+      "title": "Arterial Spin Labeling",
+      "description": "A non-invasive MRI technique for measuring cerebral blood flow."
+    },
+    {
+      "terms": [
+        "MNI"
+      ],
+      "title": "Montreal Neurological Institute",
+      "description": "A standard brain coordinate space (MNI-152) used for spatial normalization."
+    },
+    {
+      "terms": [
+        "Talairach"
+      ],
+      "title": "Talairach-Tournoux Atlas",
+      "description": "Stereotactic atlas coordinate system for mapping brain structures."
+    },
+    {
+      "terms": [
+        "AAL"
+      ],
+      "title": "Automated Anatomical Labeling",
+      "description": "A brain atlas that parcellates the cortex into anatomical regions."
+    },
+    {
+      "terms": [
+        "RAI"
+      ],
+      "title": "Right-Anterior-Inferior",
+      "description": "A neuroimaging coordinate system convention where axes point right, anterior, and inferior (AFNI default)."
+    },
+    {
+      "terms": [
+        "RAS"
+      ],
+      "title": "Right-Anterior-Superior",
+      "description": "A neuroimaging coordinate system convention where axes point right, anterior, and superior."
+    },
+    {
+      "terms": [
+        "LAS"
+      ],
+      "title": "Left-Anterior-Superior",
+      "description": "A neuroimaging coordinate system convention where axes point left, anterior, and superior."
+    },
+    {
+      "terms": [
+        "LPS"
+      ],
+      "title": "Left-Posterior-Superior",
+      "description": "A neuroimaging coordinate system convention where axes point left, posterior, and superior (DICOM default)."
+    },
+    {
+      "terms": [
+        "AP"
+      ],
+      "title": "Anterior-Posterior",
+      "description": "A phase encoding direction running from the front to the back of the head."
+    },
+    {
+      "terms": [
+        "PA"
+      ],
+      "title": "Posterior-Anterior",
+      "description": "A phase encoding direction running from the back to the front of the head."
+    },
+    {
+      "terms": [
+        "LR"
+      ],
+      "title": "Left-Right",
+      "description": "A direction or phase encoding axis running from left to right."
+    },
+    {
+      "terms": [
+        "RL"
+      ],
+      "title": "Right-Left",
+      "description": "A direction or phase encoding axis running from right to left."
+    },
+    {
+      "terms": [
+        "SI"
+      ],
+      "title": "Superior-Inferior",
+      "description": "A direction or phase encoding axis running from top to bottom of the head."
+    },
+    {
+      "terms": [
+        "CT"
+      ],
+      "title": "Computed Tomography",
+      "description": "An X-ray-based imaging technique that produces cross-sectional images of the body."
+    },
+    {
+      "terms": [
+        "QC"
+      ],
+      "title": "Quality Control",
+      "description": "The process of checking data or results for artifacts, errors, or quality issues."
+    },
+    {
+      "terms": [
+        "CC"
+      ],
+      "title": "Cross-Correlation",
+      "description": "A similarity metric used in image registration to measure alignment between images."
+    },
+    {
+      "terms": [
+        "BBR"
+      ],
+      "title": "Boundary-Based Registration",
+      "description": "A registration method that aligns images by optimizing contrast at tissue boundaries (e.g. white/gray matter)."
+    },
+    {
+      "terms": [
+        "N4"
+      ],
+      "title": "N4 Bias Field Correction",
+      "description": "An algorithm for correcting intensity non-uniformity (bias field) artifacts in MRI, from the ANTs toolkit."
+    },
+    {
+      "terms": [
+        "FC"
+      ],
+      "title": "Functional Connectivity",
+      "description": "The statistical association between time series of spatially distinct brain regions."
+    },
+    {
+      "terms": [
+        "aparc"
+      ],
+      "title": "Automatic Cortical Parcellation",
+      "description": "A FreeSurfer atlas that divides the cortical surface into anatomical regions based on gyral and sulcal geometry."
+    },
+    {
+      "terms": [
+        "aseg"
+      ],
+      "title": "Automatic Subcortical Segmentation",
+      "description": "A FreeSurfer atlas that labels subcortical brain structures such as hippocampus, amygdala, and thalamus."
+    }
+  ]
+}

--- a/tooling/src/wrap/apps/hub_build/__init__.py
+++ b/tooling/src/wrap/apps/hub_build/__init__.py
@@ -9,6 +9,7 @@ Emitted under ``--out`` (which maps to ``niwrap.dev/niwrap/`` once published):
     index.json                                releases registry (latest + versions)
     <version>/catalog.json                    the one manifest the hub fetches
     <version>/descriptors/<pkg>/<app>.json     verbatim descriptor copies
+    <version>/glossary.json                   neuroimaging term glossary (when present)
 
 ``<version>`` is the niwrap release version (``project.json``). Each package
 contributes its default version as metadata; the descriptor path is keyed by
@@ -33,7 +34,7 @@ from wrap.catalog_niwrap import (
     iter_apps_niwrap,
     iter_packages_niwrap,
 )
-from wrap.utils import write_json
+from wrap.utils import read_json, write_json
 
 #: Default compiler pin recorded in the manifest. Must match the ``@styx-api/core``
 #: version the hub bundles, so the rendered snippets/command line a user sees match
@@ -45,6 +46,10 @@ SCHEMA_VERSION = 1
 
 #: Sub-directory (relative to a version's catalog.json) holding the descriptors.
 DESCRIPTOR_BASE = "descriptors"
+
+#: Filename of the published glossary (relative to a version's catalog.json),
+#: copied from the project source (``src/<project>/glossary.json``) when present.
+GLOSSARY_FILE = "glossary.json"
 
 #: Cap on the embedded per-app summary; full text stays in the descriptor.
 MAX_SUMMARY_CHARS = 240
@@ -151,15 +156,24 @@ def build_hub_layout(out_dir: Path, compiler: str) -> dict[str, int]:
 
     packages = [_package_entry(pkg, version_dir) for pkg in iter_packages_niwrap()]
 
-    catalog = {
+    # Publish the project's neuroimaging glossary next to the catalog when present,
+    # so every front-end (hub, docs) annotates descriptions from one shared source.
+    glossary_src = project["__path__"].parent / GLOSSARY_FILE
+    has_glossary = glossary_src.exists()
+    if has_glossary:
+        write_json(version_dir / GLOSSARY_FILE, read_json(glossary_src))
+
+    catalog: dict[str, Any] = {
         "schemaVersion": SCHEMA_VERSION,
         "project": project["name"],
         "version": version,
         "compiler": _compiler_object(compiler),
         "descriptorBase": DESCRIPTOR_BASE,
-        "docs": project.get("docs", {}),
-        "packages": packages,
     }
+    if has_glossary:
+        catalog["glossary"] = GLOSSARY_FILE
+    catalog["docs"] = project.get("docs", {})
+    catalog["packages"] = packages
     write_json(version_dir / "catalog.json", catalog)
 
     index = {

--- a/tooling/tests/test_hub_build.py
+++ b/tooling/tests/test_hub_build.py
@@ -124,6 +124,37 @@ def test_descriptors_copied_verbatim(catalog_root: pl.Path) -> None:
     assert dst.read_bytes() == src.read_bytes()
 
 
+def test_glossary_published_when_present(catalog_root: pl.Path) -> None:
+    glossary = {
+        "entries": [
+            {
+                "terms": ["FSL"],
+                "title": "FMRIB Software Library",
+                "description": "A neuroimaging analysis library.",
+            }
+        ]
+    }
+    _write(catalog_root / "src" / "niwrap" / "glossary.json", glossary)
+
+    out = catalog_root / "out"
+    build_hub_layout(out, DEFAULT_COMPILER)
+
+    catalog = json.loads((out / "9.9.9" / "catalog.json").read_text(encoding="utf-8"))
+    assert catalog["glossary"] == "glossary.json"
+    published = json.loads((out / "9.9.9" / "glossary.json").read_text(encoding="utf-8"))
+    assert published == glossary
+
+
+def test_glossary_absent_omits_key(catalog_root: pl.Path) -> None:
+    # The default fixture has no glossary.json; the key and file are simply absent.
+    out = catalog_root / "out"
+    build_hub_layout(out, DEFAULT_COMPILER)
+
+    catalog = json.loads((out / "9.9.9" / "catalog.json").read_text(encoding="utf-8"))
+    assert "glossary" not in catalog
+    assert not (out / "9.9.9" / "glossary.json").exists()
+
+
 def test_clean_rebuild_drops_stale_descriptors(catalog_root: pl.Path) -> None:
     out = catalog_root / "out"
     build_hub_layout(out, DEFAULT_COMPILER)


### PR DESCRIPTION
## What

Adds a project-level **glossary of neuroimaging terms** (abbreviations + their expanded names + short definitions) as first-class niwrap metadata, and publishes it alongside the catalog so every front-end can annotate tool documentation with inline definitions from **one shared, versioned source**.

Today the glossary lives hardcoded in the hub (`niwrap-hub/.../glossary/glossary.ts`, 150 entries). As the static docs site also needs it, the data belongs in niwrap (the producer of the published knowledge), not duplicated in each front-end.

## Changes

- **`src/niwrap/glossary.json`** — new source file, 150 entries, seeded verbatim from the hub's in-tree glossary (`{ terms[], title, description }`).
- **`schemas/glossary.schema.json`** — schema for the new file, registered in `.vscode/settings.json`. The schema-validation workflow treats `glossary.json` like `projects.json` (a project-level file with no `name`), so the name-convention check is skipped for it.
- **`wrap hub-build`** — copies the glossary to `<version>/glossary.json` and references it from `catalog.json` (`"glossary": "glossary.json"`). The key/file are omitted when no glossary is present, so the change is a no-op for catalogs without one.
- **Tests** — cover both the present and absent cases.

Published layout becomes:

```
<version>/catalog.json     # now carries "glossary": "glossary.json" when present
<version>/glossary.json    # the term dictionary
```

## Why not `project.json`

`project.docs` describes the *catalog itself* (`title/description/authors/...`); a 150-entry term dictionary is a different kind of object with a different lifecycle (it barely changes between releases). Keeping it as its own published resource avoids overloading the manifest and lets consumers fetch it independently.

## Notes / follow-ups (intentionally out of scope)

- The hub keeps its own copy for now — some duplication is fine until we revisit a shared ingestion/matcher package.
- Suite/tool terms (FSL, BET, …) overlap with existing `package.json` / `app.json` docs; deriving those from the manifest (so the hand-maintained set shrinks to general vocabulary) is a natural next step.
- Published per release for build reproducibility.

## Verification

- `ruff check` / `ruff format --check` / `mypy` clean
- `pytest tests/test_hub_build.py` — 7 passed
- `glossary.json` validates against the new schema (ajv)
- Real `wrap hub-build` emits `1.0.1/glossary.json` (150 entries) and the catalog reference