### PR TITLE
chore(release): niwrap 1.0.2 (styx-ts 0.5.1 / suite namespace fix)

### DIFF
--- a/src/niwrap/project.json
+++ b/src/niwrap/project.json
@@ -1,6 +1,6 @@
 {
   "name": "niwrap",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "packages": [
     "afni",

--- a/tooling/compile.sh
+++ b/tooling/compile.sh
@@ -23,13 +23,14 @@ set -euo pipefail
 # releases are reproducible; bump deliberately and coordinate with the hub's
 # bundled @styx/core version (see the styx2 v1-replacement plan).
 #
-# Pinned to styx-ts main at the 0.5.0 release (#41) - the metapackage now
-# re-exports styxkit so `import niwrap; niwrap.use_docker()` works again (#39),
-# plus the module-naming hardening (#40). Keep in lockstep with the hub-gate /
-# DEFAULT_COMPILER @styx-api/core@0.5.0 pin; bump deliberately.
+# Pinned to styx-ts main at the 0.5.1 release (#43) - suites now nest under the
+# metapackage namespace so `from niwrap import fsl` / `niwrap.fsl.bet(...)` work
+# again (#42), restoring the v1 import ergonomic the 0.5.0 per-suite split broke.
+# Keep in lockstep with the hub-gate / DEFAULT_COMPILER @styx-api/core@0.5.1 pin;
+# bump deliberately.
 # -----------------------------------------------------------------------------
 STYX2_REPO="${STYX2_REPO:-https://github.com/styx-api/styx-ts.git}"
-STYX2_REF="${STYX2_REF:-7d8b41aa20a0a677deb1ce0286d01fa9fc17e2ae}"
+STYX2_REF="${STYX2_REF:-8a3296b2139be34dd85ab9fe12b7b5032cd9f854}"
 
 TARGETS="${1:-python,typescript,json-schema}"
 

--- a/tooling/hub-gate/package-lock.json
+++ b/tooling/hub-gate/package-lock.json
@@ -8,7 +8,7 @@
       "name": "niwrap-hub-gate",
       "version": "0.0.0",
       "dependencies": {
-        "@styx-api/core": "0.5.0",
+        "@styx-api/core": "0.5.1",
         "styxdefs": "^0.2.0",
         "sucrase": "^3.35.0"
       }
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@styx-api/core": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@styx-api/core/-/core-0.5.0.tgz",
-      "integrity": "sha512-TvexBWgAgHWdeIu19XmTlLi/sEcR+5spnR3NsVMs/pqow9/pF7yvXEjEJd4+uj5e/3c2m9lpcj0ZhY0pyY8RnA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@styx-api/core/-/core-0.5.1.tgz",
+      "integrity": "sha512-Szo5y3cShwAXMFSgZqXjRs91c0xSLAyk/gBB1WE3BFyJ/wNndi2fs3v0qMJa8S8iD6NCUMd+A81LHvnano8wBg==",
       "license": "MIT"
     },
     "node_modules/any-promise": {

--- a/tooling/hub-gate/package.json
+++ b/tooling/hub-gate/package.json
@@ -8,7 +8,7 @@
     "gate": "node gate.mjs"
   },
   "dependencies": {
-    "@styx-api/core": "0.5.0",
+    "@styx-api/core": "0.5.1",
     "styxdefs": "^0.2.0",
     "sucrase": "^3.35.0"
   }

--- a/tooling/src/wrap/apps/hub_build/__init__.py
+++ b/tooling/src/wrap/apps/hub_build/__init__.py
@@ -39,7 +39,7 @@ from wrap.utils import read_json, write_json
 #: Default compiler pin recorded in the manifest. Must match the ``@styx-api/core``
 #: version the hub bundles, so the rendered snippets/command line a user sees match
 #: the published ``niwrap`` package (the C8 lockstep). Override with ``--compiler``.
-DEFAULT_COMPILER = "@styx-api/core@0.5.0"
+DEFAULT_COMPILER = "@styx-api/core@0.5.1"
 
 #: Bump when the manifest shape changes incompatibly, so the hub can guard on it.
 SCHEMA_VERSION = 1

--- a/tooling/tests/test_hub_build.py
+++ b/tooling/tests/test_hub_build.py
@@ -88,7 +88,7 @@ def test_build_hub_layout(catalog_root: pl.Path) -> None:
     assert catalog["schemaVersion"] == 1
     assert catalog["project"] == "niwrap"
     assert catalog["version"] == "9.9.9"
-    assert catalog["compiler"] == {"name": "@styx-api/core", "version": "0.5.0"}
+    assert catalog["compiler"] == {"name": "@styx-api/core", "version": "0.5.1"}
     assert catalog["descriptorBase"] == "descriptors"
     assert catalog["docs"]["title"] == "Demo"
     assert len(catalog["packages"]) == 1
@@ -175,9 +175,9 @@ def test_summary_first_line_and_cap() -> None:
 
 
 def test_compiler_object_keeps_scope() -> None:
-    assert _compiler_object("@styx-api/core@0.5.0") == {
+    assert _compiler_object("@styx-api/core@0.5.1") == {
         "name": "@styx-api/core",
-        "version": "0.5.0",
+        "version": "0.5.1",
     }
     assert _compiler_object("styx@1.2.3") == {"name": "styx", "version": "1.2.3"}
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Why

`pip install niwrap` (1.0.1) broke the canonical import:

```python
from niwrap import fsl     # ❌ ImportError in 1.0.1
```

1.0.1 was compiled with styx-ts **0.5.0**, whose per-suite-distribution split made each suite a top-level module (`fsl`) and left `niwrap` as a styxkit-only re-export. styx-ts **0.5.1** (styx-api/styx-ts#42, released in #43) fixes this by nesting each suite under the metapackage namespace (`niwrap.fsl` via setuptools `package-dir`).

## What

Re-pin the catalog compiler to styx-ts 0.5.1 and cut a patch release, mirroring the lockstep shape of the 1.0.1 release (#315):

- `tooling/compile.sh`: `STYX2_REF` → `8a3296b` (0.5.1 release commit)
- `src/niwrap/project.json`: `1.0.1` → `1.0.2`
- `tooling/src/wrap/apps/hub_build/__init__.py` + `tooling/hub-gate/package.json` (+ lock) + `tooling/tests/test_hub_build.py`: `@styx-api/core` `0.5.0` → `0.5.1` (hub lockstep)

| Import (after 1.0.2) | Result |
|---|---|
| `from niwrap import fsl` | ✅ |
| `niwrap.fsl.bet(...)` | ✅ |
| `niwrap.use_docker()` | ✅ (kept) |
| `import fsl` (top-level pollution) | ✅ gone |

## Verification (local, with the real catalog)

- `tooling/compile.sh python`: **1878 tools compiled, 0 failed**; `dist/niwrap-python/fsl/pyproject.toml` → `packages = ["niwrap.fsl"]`, `package-dir = { "niwrap.fsl" = "." }`.
- Built + `pip install`ed the actual generated `niwrap-1.0.2` + `niwrap_dcm2niix-1.0.2` wheels (styxkit/styxdefs from PyPI): `from niwrap import dcm2niix` → `niwrap.dcm2niix`, `niwrap.use_docker()` works, top-level `import dcm2niix` correctly fails.
- `tooling/tests/test_hub_build.py`: 7 passed.

## Release step

After merge, tag `v1.0.2` on main to trigger `publish-pypi.yaml` (compiles fresh, builds with `uv`, publishes with `skip-existing: true`).
