### PR TITLE
chore(release): niwrap 1.0.3 (styx-ts 0.5.3 / container + pin)

### DIFF
--- a/src/niwrap/project.json
+++ b/src/niwrap/project.json
@@ -1,6 +1,6 @@
 {
   "name": "niwrap",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "packages": [
     "afni",

--- a/tooling/compile.sh
+++ b/tooling/compile.sh
@@ -23,14 +23,15 @@ set -euo pipefail
 # releases are reproducible; bump deliberately and coordinate with the hub's
 # bundled @styx/core version (see the styx2 v1-replacement plan).
 #
-# Pinned to styx-ts main at the 0.5.1 release (#43) - suites now nest under the
-# metapackage namespace so `from niwrap import fsl` / `niwrap.fsl.bet(...)` work
-# again (#42), restoring the v1 import ergonomic the 0.5.0 per-suite split broke.
-# Keep in lockstep with the hub-gate / DEFAULT_COMPILER @styx-api/core@0.5.1 pin;
-# bump deliberately.
+# Pinned to styx-ts main at the 0.5.3 release (#47) - tool Metadata now carries
+# the package/version container image (#46), so the docker/singularity runners
+# have an image to pull again. Also includes the suite-dep pinning fix (#44, so a
+# mid-propagation `pip install` can't mix versions) on top of the 0.5.1 suite-
+# namespace fix (#42). Keep in lockstep with the hub-gate / DEFAULT_COMPILER
+# @styx-api/core@0.5.3 pin; bump deliberately.
 # -----------------------------------------------------------------------------
 STYX2_REPO="${STYX2_REPO:-https://github.com/styx-api/styx-ts.git}"
-STYX2_REF="${STYX2_REF:-8a3296b2139be34dd85ab9fe12b7b5032cd9f854}"
+STYX2_REF="${STYX2_REF:-41e8aa708c480042bdc4c21813e3faee8aab07be}"
 
 TARGETS="${1:-python,typescript,json-schema}"
 

--- a/tooling/hub-gate/package-lock.json
+++ b/tooling/hub-gate/package-lock.json
@@ -8,7 +8,7 @@
       "name": "niwrap-hub-gate",
       "version": "0.0.0",
       "dependencies": {
-        "@styx-api/core": "0.5.1",
+        "@styx-api/core": "0.5.3",
         "styxdefs": "^0.2.0",
         "sucrase": "^3.35.0"
       }
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@styx-api/core": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@styx-api/core/-/core-0.5.1.tgz",
-      "integrity": "sha512-Szo5y3cShwAXMFSgZqXjRs91c0xSLAyk/gBB1WE3BFyJ/wNndi2fs3v0qMJa8S8iD6NCUMd+A81LHvnano8wBg==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@styx-api/core/-/core-0.5.3.tgz",
+      "integrity": "sha512-G04G6CSLIupO1AJowRSoA/mnQiOfiPnRNIqbBO6EpBldBnURuNpjz9AhuGZecTc5GYwRKC14PXpcbx7vhy8Isw==",
       "license": "MIT"
     },
     "node_modules/any-promise": {

--- a/tooling/hub-gate/package.json
+++ b/tooling/hub-gate/package.json
@@ -8,7 +8,7 @@
     "gate": "node gate.mjs"
   },
   "dependencies": {
-    "@styx-api/core": "0.5.1",
+    "@styx-api/core": "0.5.3",
     "styxdefs": "^0.2.0",
     "sucrase": "^3.35.0"
   }

--- a/tooling/src/wrap/apps/hub_build/__init__.py
+++ b/tooling/src/wrap/apps/hub_build/__init__.py
@@ -39,7 +39,7 @@ from wrap.utils import read_json, write_json
 #: Default compiler pin recorded in the manifest. Must match the ``@styx-api/core``
 #: version the hub bundles, so the rendered snippets/command line a user sees match
 #: the published ``niwrap`` package (the C8 lockstep). Override with ``--compiler``.
-DEFAULT_COMPILER = "@styx-api/core@0.5.1"
+DEFAULT_COMPILER = "@styx-api/core@0.5.3"
 
 #: Bump when the manifest shape changes incompatibly, so the hub can guard on it.
 SCHEMA_VERSION = 1

--- a/tooling/tests/test_hub_build.py
+++ b/tooling/tests/test_hub_build.py
@@ -88,7 +88,7 @@ def test_build_hub_layout(catalog_root: pl.Path) -> None:
     assert catalog["schemaVersion"] == 1
     assert catalog["project"] == "niwrap"
     assert catalog["version"] == "9.9.9"
-    assert catalog["compiler"] == {"name": "@styx-api/core", "version": "0.5.1"}
+    assert catalog["compiler"] == {"name": "@styx-api/core", "version": "0.5.3"}
     assert catalog["descriptorBase"] == "descriptors"
     assert catalog["docs"]["title"] == "Demo"
     assert len(catalog["packages"]) == 1
@@ -175,9 +175,9 @@ def test_summary_first_line_and_cap() -> None:
 
 
 def test_compiler_object_keeps_scope() -> None:
-    assert _compiler_object("@styx-api/core@0.5.1") == {
+    assert _compiler_object("@styx-api/core@0.5.3") == {
         "name": "@styx-api/core",
-        "version": "0.5.1",
+        "version": "0.5.3",
     }
     assert _compiler_object("styx@1.2.3") == {"name": "styx", "version": "1.2.3"}
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Why

Re-pin the catalog compiler to styx-ts 0.5.3 (#47) and cut niwrap 1.0.3. This jumps from the 0.5.1 pin and bundles **two** compiler fixes (updated from the original 0.5.2-only proposal - 0.5.3 is a superset):

- **container metadata** (styx-ts #46, the critical one): tool `Metadata` now carries the package/version container image from `version.json`, so the docker/singularity runners have an image to pull again. It was `None` for nearly every tool, e.g.:
  ```python
  fsl.BET_METADATA  # before: container_image_tag=None
  ```
- **suite-dep pinning** (styx-ts #44): the metapackage pins each suite to the exact project version, so a mid-propagation `pip install niwrap==X` can't graft an old-layout suite onto the new metapackage.

Plus the 0.5.1 suite-namespace fix (#42) already in 1.0.2.

## Verification (local, real catalog)

- `tooling/compile.sh python`: 1878 tools compiled, 0 failed.
- `dist/niwrap-python/fsl/bet.py` -> `container_image_tag="brainlife/fsl:6.0.4-patched2"`; `mrtrix/mrconvert.py` -> `container_image_tag="mrtrix3/mrtrix3:3.0.4"` (each package gets its own version container).
- `dist/niwrap-python/niwrap/pyproject.toml` pins `niwrap_fsl==1.0.3`, `niwrap_ants==1.0.3`, ...
- `tooling/tests/test_hub_build.py`: 7 passed.

## Release step

After merge, tag `v1.0.3` to trigger `publish-pypi.yaml`.
