### PR TITLE
chore(release): niwrap 1.0.4 (styx-ts 0.6.0 / nested factories + snake_case)

### DIFF
--- a/src/niwrap/project.json
+++ b/src/niwrap/project.json
@@ -1,6 +1,6 @@
 {
   "name": "niwrap",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "MIT",
   "packages": [
     "afni",

--- a/tooling/compile.sh
+++ b/tooling/compile.sh
@@ -23,15 +23,17 @@ set -euo pipefail
 # releases are reproducible; bump deliberately and coordinate with the hub's
 # bundled @styx/core version (see the styx2 v1-replacement plan).
 #
-# Pinned to styx-ts main at the 0.5.3 release (#47) - tool Metadata now carries
-# the package/version container image (#46), so the docker/singularity runners
-# have an image to pull again. Also includes the suite-dep pinning fix (#44, so a
-# mid-propagation `pip install` can't mix versions) on top of the 0.5.1 suite-
-# namespace fix (#42). Keep in lockstep with the hub-gate / DEFAULT_COMPILER
-# @styx-api/core@0.5.3 pin; bump deliberately.
+# Pinned to styx-ts main at the 0.6.0 release (#48) - the Python backend now
+# emits a `_params` factory for every nested struct / union variant (restoring
+# the v1 builder pattern, e.g. `ants.n4_bias_field_correction_corrected_output_params(...)`
+# instead of a hand-authored `{"@type": ...}` dict) and snake_cases the host
+# kwarg names. NOTE: snake_casing applies to root wrappers too, so tools with
+# camelCase wire ids change their public kwargs - a breaking change for end-user
+# code. TypeScript snippets are unchanged. Keep in lockstep with the hub-gate /
+# DEFAULT_COMPILER @styx-api/core@0.6.0 pin; bump deliberately.
 # -----------------------------------------------------------------------------
 STYX2_REPO="${STYX2_REPO:-https://github.com/styx-api/styx-ts.git}"
-STYX2_REF="${STYX2_REF:-41e8aa708c480042bdc4c21813e3faee8aab07be}"
+STYX2_REF="${STYX2_REF:-c474f3c17613f73accd03471361602564a62a07a}"
 
 TARGETS="${1:-python,typescript,json-schema}"
 

--- a/tooling/hub-gate/package-lock.json
+++ b/tooling/hub-gate/package-lock.json
@@ -8,7 +8,7 @@
       "name": "niwrap-hub-gate",
       "version": "0.0.0",
       "dependencies": {
-        "@styx-api/core": "0.5.3",
+        "@styx-api/core": "0.6.0",
         "styxdefs": "^0.2.0",
         "sucrase": "^3.35.0"
       }
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@styx-api/core": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@styx-api/core/-/core-0.5.3.tgz",
-      "integrity": "sha512-G04G6CSLIupO1AJowRSoA/mnQiOfiPnRNIqbBO6EpBldBnURuNpjz9AhuGZecTc5GYwRKC14PXpcbx7vhy8Isw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@styx-api/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-eUCOJBTOzoOggBhByVd7roBtoeDEH4WfnGVLqnxwI/8ksuzQ/8pT+QFq5hnBKSH9tRDPV/vOJ8G9WZ+4I1zQ9A==",
       "license": "MIT"
     },
     "node_modules/any-promise": {

--- a/tooling/hub-gate/package.json
+++ b/tooling/hub-gate/package.json
@@ -8,7 +8,7 @@
     "gate": "node gate.mjs"
   },
   "dependencies": {
-    "@styx-api/core": "0.5.3",
+    "@styx-api/core": "0.6.0",
     "styxdefs": "^0.2.0",
     "sucrase": "^3.35.0"
   }

--- a/tooling/src/wrap/apps/hub_build/__init__.py
+++ b/tooling/src/wrap/apps/hub_build/__init__.py
@@ -39,7 +39,7 @@ from wrap.utils import read_json, write_json
 #: Default compiler pin recorded in the manifest. Must match the ``@styx-api/core``
 #: version the hub bundles, so the rendered snippets/command line a user sees match
 #: the published ``niwrap`` package (the C8 lockstep). Override with ``--compiler``.
-DEFAULT_COMPILER = "@styx-api/core@0.5.3"
+DEFAULT_COMPILER = "@styx-api/core@0.6.0"
 
 #: Bump when the manifest shape changes incompatibly, so the hub can guard on it.
 SCHEMA_VERSION = 1

--- a/tooling/tests/test_hub_build.py
+++ b/tooling/tests/test_hub_build.py
@@ -88,7 +88,7 @@ def test_build_hub_layout(catalog_root: pl.Path) -> None:
     assert catalog["schemaVersion"] == 1
     assert catalog["project"] == "niwrap"
     assert catalog["version"] == "9.9.9"
-    assert catalog["compiler"] == {"name": "@styx-api/core", "version": "0.5.3"}
+    assert catalog["compiler"] == {"name": "@styx-api/core", "version": "0.6.0"}
     assert catalog["descriptorBase"] == "descriptors"
     assert catalog["docs"]["title"] == "Demo"
     assert len(catalog["packages"]) == 1
@@ -175,9 +175,9 @@ def test_summary_first_line_and_cap() -> None:
 
 
 def test_compiler_object_keeps_scope() -> None:
-    assert _compiler_object("@styx-api/core@0.5.3") == {
+    assert _compiler_object("@styx-api/core@0.6.0") == {
         "name": "@styx-api/core",
-        "version": "0.5.3",
+        "version": "0.6.0",
     }
     assert _compiler_object("styx@1.2.3") == {"name": "styx", "version": "1.2.3"}
     with pytest.raises(ValueError):


### PR DESCRIPTION
@
Re-pins the catalog compiler to **styx-ts 0.6.0** ([styx-ts#48](https://github.com/styx-api/styx-ts/pull/48), published to npm) and cuts **niwrap 1.0.4**.

## What changes for users
The Python backend now emits a `_params` factory for every nested struct / union variant, restoring the v1 builder pattern:

```python
ants.n4_bias_field_correction(
    image_dimensionality=3,
    input_image="input.nii.gz",
    output=ants.n4_bias_field_correction_corrected_output_params(
        corrected_output_file_name="output.nii.gz",
    ),
)
```

instead of a hand-authored `output={"@type": "correctedOutput", ...}` dict. The factory injects `@type` itself.

## ⚠️ Breaking change
Host kwarg names are now **snake_cased**, including on **root wrappers** - tools with camelCase wire ids change their public kwargs (e.g. `correctedOutput=` -> `corrected_output=`). Top-level fields authored snake_case are unchanged. TypeScript wrappers are unaffected. Shipping as `1.0.4` per the maintainer steer; calling it out prominently here.

## Changeset (6 files, standard release shape)
- `src/niwrap/project.json` - version `1.0.3` -> `1.0.4`
- `tooling/compile.sh` - `STYX2_REF` -> `c474f3c` (styx-ts 0.6.0) + refreshed pin comment
- `tooling/hub-gate/{package.json,package-lock.json}` - `@styx-api/core` `0.5.3` -> `0.6.0`
- `tooling/src/wrap/apps/hub_build/__init__.py` - `DEFAULT_COMPILER` -> `@styx-api/core@0.6.0`
- `tooling/tests/test_hub_build.py` - assertions `0.5.3` -> `0.6.0`

## Validation
- `tooling` hub_build tests pass locally (7/7).
- The full catalog is regenerated + type-checked against 0.6.0 by the `typecheck-codegen` CI job (the authoritative cross-tool check).

## Release steps after merge (not done here)
1. Tag `v1.0.4` + push -> triggers `publish-pypi`.
2. Manually dispatch `publish-npm` and `publish-pages`.
@