### PR TITLE
chore(release): niwrap 1.0.5 (styx-ts 0.6.1 / flag-fusion + variant pass)

### DIFF
--- a/src/niwrap/project.json
+++ b/src/niwrap/project.json
@@ -1,6 +1,6 @@
 {
   "name": "niwrap",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT",
   "packages": [
     "afni",

--- a/tooling/compile.sh
+++ b/tooling/compile.sh
@@ -23,17 +23,19 @@ set -euo pipefail
 # releases are reproducible; bump deliberately and coordinate with the hub's
 # bundled @styx/core version (see the styx2 v1-replacement plan).
 #
-# Pinned to styx-ts main at the 0.6.0 release (#48) - the Python backend now
-# emits a `_params` factory for every nested struct / union variant (restoring
-# the v1 builder pattern, e.g. `ants.n4_bias_field_correction_corrected_output_params(...)`
-# instead of a hand-authored `{"@type": ...}` dict) and snake_cases the host
-# kwarg names. NOTE: snake_casing applies to root wrappers too, so tools with
-# camelCase wire ids change their public kwargs - a breaking change for end-user
-# code. TypeScript snippets are unchanged. Keep in lockstep with the hub-gate /
-# DEFAULT_COMPILER @styx-api/core@0.6.0 pin; bump deliberately.
+# Pinned to styx-ts main at the 0.6.1 release (#53) - a patch over 0.6.0 (#48,
+# nested `_params` factories + snake_case kwargs) bundling two codegen fixes:
+#   - #49 (boutiques): a `command-line-flag-separator` flag and its value now
+#     fuse into a single argv token (e.g. `--imain=<file>`) instead of two
+#     separate tokens - fixes 27 tools (fsl/afni/dcm2niix).
+#   - #50 (python): a command-less union variant (an off/none/help mode) emits
+#     `pass` instead of an empty dispatch branch - repairs 5 ants modules that
+#     were an IndentationError (making `import niwrap.ants` fail).
+# Keep in lockstep with the hub-gate / DEFAULT_COMPILER @styx-api/core@0.6.1
+# pin; bump deliberately.
 # -----------------------------------------------------------------------------
 STYX2_REPO="${STYX2_REPO:-https://github.com/styx-api/styx-ts.git}"
-STYX2_REF="${STYX2_REF:-c474f3c17613f73accd03471361602564a62a07a}"
+STYX2_REF="${STYX2_REF:-9f7b7102ac90517e31c1f44435a0a490eb567edd}"
 
 TARGETS="${1:-python,typescript,json-schema}"
 

--- a/tooling/hub-gate/package-lock.json
+++ b/tooling/hub-gate/package-lock.json
@@ -8,7 +8,7 @@
       "name": "niwrap-hub-gate",
       "version": "0.0.0",
       "dependencies": {
-        "@styx-api/core": "0.6.0",
+        "@styx-api/core": "0.6.1",
         "styxdefs": "^0.2.0",
         "sucrase": "^3.35.0"
       }
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@styx-api/core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@styx-api/core/-/core-0.6.0.tgz",
-      "integrity": "sha512-eUCOJBTOzoOggBhByVd7roBtoeDEH4WfnGVLqnxwI/8ksuzQ/8pT+QFq5hnBKSH9tRDPV/vOJ8G9WZ+4I1zQ9A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@styx-api/core/-/core-0.6.1.tgz",
+      "integrity": "sha512-73b3T+wPN0MbHCKRhoi88K1Vq8+HERtyb06P1a9pyGd5I0ZceHJNhGG8wDdbuarhVXTuJG3vLoPA7KrAwNyd8g==",
       "license": "MIT"
     },
     "node_modules/any-promise": {

--- a/tooling/hub-gate/package.json
+++ b/tooling/hub-gate/package.json
@@ -8,7 +8,7 @@
     "gate": "node gate.mjs"
   },
   "dependencies": {
-    "@styx-api/core": "0.6.0",
+    "@styx-api/core": "0.6.1",
     "styxdefs": "^0.2.0",
     "sucrase": "^3.35.0"
   }

--- a/tooling/src/wrap/apps/hub_build/__init__.py
+++ b/tooling/src/wrap/apps/hub_build/__init__.py
@@ -39,7 +39,7 @@ from wrap.utils import read_json, write_json
 #: Default compiler pin recorded in the manifest. Must match the ``@styx-api/core``
 #: version the hub bundles, so the rendered snippets/command line a user sees match
 #: the published ``niwrap`` package (the C8 lockstep). Override with ``--compiler``.
-DEFAULT_COMPILER = "@styx-api/core@0.6.0"
+DEFAULT_COMPILER = "@styx-api/core@0.6.1"
 
 #: Bump when the manifest shape changes incompatibly, so the hub can guard on it.
 SCHEMA_VERSION = 1

--- a/tooling/tests/test_hub_build.py
+++ b/tooling/tests/test_hub_build.py
@@ -88,7 +88,7 @@ def test_build_hub_layout(catalog_root: pl.Path) -> None:
     assert catalog["schemaVersion"] == 1
     assert catalog["project"] == "niwrap"
     assert catalog["version"] == "9.9.9"
-    assert catalog["compiler"] == {"name": "@styx-api/core", "version": "0.6.0"}
+    assert catalog["compiler"] == {"name": "@styx-api/core", "version": "0.6.1"}
     assert catalog["descriptorBase"] == "descriptors"
     assert catalog["docs"]["title"] == "Demo"
     assert len(catalog["packages"]) == 1
@@ -175,9 +175,9 @@ def test_summary_first_line_and_cap() -> None:
 
 
 def test_compiler_object_keeps_scope() -> None:
-    assert _compiler_object("@styx-api/core@0.6.0") == {
+    assert _compiler_object("@styx-api/core@0.6.1") == {
         "name": "@styx-api/core",
-        "version": "0.6.0",
+        "version": "0.6.1",
     }
     assert _compiler_object("styx@1.2.3") == {"name": "styx", "version": "1.2.3"}
     with pytest.raises(ValueError):


### PR DESCRIPTION
Re-pin the catalog compiler to **styx-ts 0.6.1** (styx-api/styx-ts#53) and cut **1.0.5**. A patch over 0.6.0 (#48), bundling two codegen fixes. No descriptor changes; compiler pin + lockstep only.

## Fixes pulled in
- **Flag-separator fusion** (styx-api/styx-ts#49): a `command-line-flag-separator` flag and its value now fuse into a single argv token (e.g. `--imain=<file>`) instead of two separate tokens `["--imain=", "<file>"]`. Repairs **27 tools** emitting malformed command lines — `fsl` ×23 (incl. `eddy`, `topup`, `fnirt`, `applywarp`, `randomise`), `afni` ×3, `dcm2niix`.
- **Command-less variant `pass`** (styx-api/styx-ts#50): a union variant / optional contributing no arguments (an off/none/help mode) now emits `pass` instead of an empty dispatch branch. Repairs **5 `ants` modules** whose `IndentationError` made `import niwrap.ants` fail outright at 0.6.0 (`ants_longitudinal_cortical_thickness_sh`, `ants_motion_corr_stats`, `average_tensor_images`, `extract_region_from_image`, `set_direction_by_matrix`).

## Verification
Compiled the full catalog at 0.6.0 vs 0.6.1: exactly the 32 files above change, each a strict fix. The entire regenerated Python catalog imports cleanly (0 broken modules, down from 5). hub_build tests pass with the 0.6.1 pin.

## Changes (pin + lockstep, mirrors #323/#324)
- `src/niwrap/project.json`: `1.0.4 → 1.0.5`
- `tooling/compile.sh`: `STYX2_REF` → `9f7b7102ac90517e31c1f44435a0a490eb567edd` (0.6.1 release) + refreshed pin comment
- `tooling/hub-gate/package.json` + `package-lock.json`: `@styx-api/core` `0.6.0 → 0.6.1`
- `tooling/src/wrap/apps/hub_build/__init__.py`: `DEFAULT_COMPILER` `0.6.0 → 0.6.1`
- `tooling/tests/test_hub_build.py`: version assertions `0.6.0 → 0.6.1`