### PR TITLE
Add bids-validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ NiWrap provides seamless, programmatic access to powerful neuroimaging command-l
 | [NiftyReg](https://github.com/KCL-BMEIS/niftyreg) | [`1.4.0`](https://hub.docker.com/r/vnmd/niftyreg_1.4.0) | ![7/7](https://progress-bar.xyz/7/?scale=7&suffix=%2F7) |
 | [Connectome Workbench](https://www.humanconnectome.org/software/connectome-workbench) | [`2.1.0`](https://hub.docker.com/r/nx10x/workbench) | ![203/203](https://progress-bar.xyz/203/?scale=203&suffix=%2F203) |
 <!-- END_PACKAGES_TABLE -->
-<small>*API Coverage: The percentages shown represent the proportion of tool binaries with available NiWrap descriptors, not the completeness of each descriptor.*</small>
+
+<small>_API Coverage: The percentages shown represent the proportion of tool binaries with available NiWrap descriptors, not the completeness of each descriptor._</small>
 
 ## 🚀 Getting Started
 
@@ -52,6 +53,7 @@ NiWrap provides seamless, programmatic access to powerful neuroimaging command-l
 ```bash
 pip install niwrap
 ```
+
 </details>
 
 <details>
@@ -62,6 +64,7 @@ npm install niwrap
 # or
 yarn add niwrap
 ```
+
 </details>
 
 <details>
@@ -71,6 +74,7 @@ yarn add niwrap
 # Not yet available on CRAN
 # Coming soon!
 ```
+
 </details>
 
 ### Basic Usage Examples
@@ -108,35 +112,37 @@ fod_outputs = mrtrix.dwi2fod(
 )
 # fod_outputs.response_odf[0].odf -> "wmfod.mif"
 ```
+
 </details>
 
 <details>
 <summary><b>TypeScript/JavaScript</b></summary>
 
 ```typescript
-import { niwrap, fsl, ants, mrtrix3 } from 'niwrap';
+import { niwrap, fsl, ants, mrtrix3 } from "niwrap";
 
 // Optional: Use Docker to run all tools (no local installation needed)
 niwrap.useDocker();
 
 // Run FSL's BET brain extraction
 const outputs = await fsl.bet({
-    input: "input.nii.gz",
-    output: "brain.nii.gz",
-    f: 0.5
+  input: "input.nii.gz",
+  output: "brain.nii.gz",
+  f: 0.5,
 });
 // outputs.outputFile -> "brain.nii.gz"
 // outputs.maskFile -> "brain_mask.nii.gz"
 
 // Calculate fiber orientation distributions with MRTrix3
 const fodOutputs = await mrtrix3.dwi2fod({
-    algorithm: "csd",
-    in_file: "dwi.mif",
-    wm_txt: "wm_response.txt",
-    wm_odf: "wmfod.mif"
+  algorithm: "csd",
+  in_file: "dwi.mif",
+  wm_txt: "wm_response.txt",
+  wm_odf: "wmfod.mif",
 });
 // fodOutputs.wmOdf -> "wmfod.mif"
 ```
+
 </details>
 
 <details>
@@ -155,6 +161,7 @@ outputs <- fsl$bet("input.nii.gz", "brain.nii.gz", fractional_intensity=0.5)
 
 # More functionality coming soon!
 ```
+
 </details>
 
 ## 🔧 Container Orchestration
@@ -176,13 +183,14 @@ niwrap.use_singularity()
 # Custom container configuration
 niwrap.use_docker()
 ```
+
 </details>
 
 <details>
 <summary><b>TypeScript/JavaScript</b></summary>
 
 ```typescript
-import { niwrap } from 'niwrap';
+import { niwrap } from "niwrap";
 
 // Use Docker containers
 niwrap.useDocker();
@@ -192,10 +200,11 @@ niwrap.useSingularity();
 
 // Custom container configuration
 niwrap.useDocker({
-    bindMounts: ["/data:/data"],
-    envs: {"CUDA_VISIBLE_DEVICES": "0"}
+  bindMounts: ["/data:/data"],
+  envs: { CUDA_VISIBLE_DEVICES: "0" },
 });
 ```
+
 </details>
 
 <details>
@@ -216,6 +225,7 @@ niwrap$use_docker(
     envs = list(CUDA_VISIBLE_DEVICES = "0")
 )
 ```
+
 </details>
 
 ## 🔍 How It Works

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ NiWrap provides seamless, programmatic access to powerful neuroimaging command-l
 | [Connectome Workbench](https://www.humanconnectome.org/software/connectome-workbench) | [`2.1.0`](https://hub.docker.com/r/nx10x/workbench) | ![203/203](https://progress-bar.xyz/203/?scale=203&suffix=%2F203) |
 <!-- END_PACKAGES_TABLE -->
 
-<small>_API Coverage: The percentages shown represent the proportion of tool binaries with available NiWrap descriptors, not the completeness of each descriptor._</small>
+<small>*API Coverage: The percentages shown represent the proportion of tool binaries with available NiWrap descriptors, not the completeness of each descriptor.*</small>
 
 ## 🚀 Getting Started
 

--- a/src/niwrap/bidsvalidator/2.4.1/bids-validator-deno/app.json
+++ b/src/niwrap/bidsvalidator/2.4.1/bids-validator-deno/app.json
@@ -5,6 +5,6 @@
     "path": "boutiques.json"
   },
   "docs": {
-    "description": "Brain Imaging Data Structure Validator"
+    "description": "The Brain Imaging Data Structure Validator checks whether a directory is compatible with the Brain Imaging Data Structure (BIDS) specification and reports validation issues in text or JSON format."
   }
 }

--- a/src/niwrap/bidsvalidator/2.4.1/bids-validator-deno/app.json
+++ b/src/niwrap/bidsvalidator/2.4.1/bids-validator-deno/app.json
@@ -1,0 +1,10 @@
+{
+  "name": "bids-validator-deno",
+  "source": {
+    "type": "boutiques",
+    "path": "boutiques.json"
+  },
+  "docs": {
+    "description": "Brain Imaging Data Structure Validator"
+  }
+}

--- a/src/niwrap/bidsvalidator/2.4.1/bids-validator-deno/boutiques.json
+++ b/src/niwrap/bidsvalidator/2.4.1/bids-validator-deno/boutiques.json
@@ -1,0 +1,207 @@
+{
+  "description": "bids-validator-deno checks whether a directory is compatible with the Brain Imaging Data Structure (BIDS) specification and reports validation issues in text or JSON format.",
+  "command-line": "bids-validator-deno [JSON] [FORMAT] [SCHEMA] [CONFIG] [MAX_ROWS] [VERBOSE] [IGNORE_WARNINGS] [IGNORE_NIFTI_HEADERS] [DEBUG] [FILENAME_MODE] [DATASET_TYPES] [BLACKLIST_MODALITIES] [RECURSIVE] [PRUNE] [OUTFILE] [PREFERRED_REMOTE] [COLOR] [DATASET_DIRECTORY]",
+  "inputs": [
+    {
+      "id": "dataset_directory",
+      "name": "Dataset directory",
+      "description": "Path to the BIDS dataset directory to validate.",
+      "type": "File",
+      "value-key": "[DATASET_DIRECTORY]"
+    },
+    {
+      "id": "json",
+      "name": "JSON output (deprecated)",
+      "description": "[Deprecated] Use --format json instead. Output machine readable JSON. When present, overrides --format and forces JSON output.",
+      "type": "Flag",
+      "command-line-flag": "--json",
+      "value-key": "[JSON]",
+      "optional": true
+    },
+    {
+      "id": "format",
+      "name": "Output format",
+      "description": "Output format: text (default), json, or json_pp (pretty-printed JSON).",
+      "type": "String",
+      "value-choices": [
+        "text",
+        "json",
+        "json_pp"
+      ],
+      "command-line-flag": "--format",
+      "value-key": "[FORMAT]",
+      "optional": true
+    },
+    {
+      "id": "schema",
+      "name": "Schema version",
+      "description": "Specify a schema version to use for validation. Accepts an arbitrary URL or a tag such as vX.Y.Z, stable, or latest. The BIDS_SCHEMA environment variable overrides this option.",
+      "type": "String",
+      "command-line-flag": "--schema",
+      "value-key": "[SCHEMA]",
+      "optional": true
+    },
+    {
+      "id": "config",
+      "name": "Configuration file",
+      "description": "Path to a JSON configuration file. The file must contain a JSON object mapping severity keys (error, warning, ignore) to arrays of issue filters.",
+      "type": "File",
+      "media-types": [
+        "application/json"
+      ],
+      "command-line-flag": "--config",
+      "value-key": "[CONFIG]",
+      "optional": true
+    },
+    {
+      "id": "max_rows",
+      "name": "Maximum TSV rows",
+      "description": "Maximum number of rows to validate in TSVs (tool default: 1000).",
+      "type": "Number",
+      "integer": true,
+      "command-line-flag": "--max-rows",
+      "value-key": "[MAX_ROWS]",
+      "optional": true
+    },
+    {
+      "id": "verbose",
+      "name": "Verbose logging",
+      "description": "Log more extensive information about issues.",
+      "type": "Flag",
+      "command-line-flag": "--verbose",
+      "value-key": "[VERBOSE]",
+      "optional": true
+    },
+    {
+      "id": "ignore_warnings",
+      "name": "Ignore warnings",
+      "description": "Disables reporting of warnings.",
+      "type": "Flag",
+      "command-line-flag": "--ignoreWarnings",
+      "value-key": "[IGNORE_WARNINGS]",
+      "optional": true
+    },
+    {
+      "id": "ignore_nifti_headers",
+      "name": "Ignore NIfTI headers",
+      "description": "Disables reading of NIfTI headers.",
+      "type": "Flag",
+      "command-line-flag": "--ignoreNiftiHeaders",
+      "value-key": "[IGNORE_NIFTI_HEADERS]",
+      "optional": true
+    },
+    {
+      "id": "debug",
+      "name": "Debug logging level",
+      "description": "Enable debug logging (tool default: ERROR; allowed values: NOTSET, DEBUG, INFO, WARNING, ERROR, CRITICAL).",
+      "type": "String",
+      "value-choices": [
+        "NOTSET",
+        "DEBUG",
+        "INFO",
+        "WARNING",
+        "ERROR",
+        "CRITICAL"
+      ],
+      "command-line-flag": "--debug",
+      "value-key": "[DEBUG]",
+      "optional": true
+    },
+    {
+      "id": "filename_mode",
+      "name": "Filename-only mode",
+      "description": "Disable schema-based filename validation and only check whether files are valid BIDS filenames.",
+      "type": "Flag",
+      "command-line-flag": "--filenameMode",
+      "value-key": "[FILENAME_MODE]",
+      "optional": true
+    },
+    {
+      "id": "dataset_types",
+      "name": "Permitted dataset types",
+      "description": "Permitted dataset types to validate against (tool default: empty list, which permits all types).",
+      "type": "String",
+      "value-choices": [
+        "raw",
+        "derivative"
+      ],
+      "list": true,
+      "command-line-flag": "--datasetTypes",
+      "value-key": "[DATASET_TYPES]",
+      "optional": true
+    },
+    {
+      "id": "blacklist_modalities",
+      "name": "Blacklisted modalities",
+      "description": "Modalities to exclude from validation (tool default: empty list). Unknown values produce a warning and are ignored; supplied values are lower-cased before lookup.",
+      "type": "String",
+      "list": true,
+      "command-line-flag": "--blacklistModalities",
+      "value-key": "[BLACKLIST_MODALITIES]",
+      "optional": true
+    },
+    {
+      "id": "recursive",
+      "name": "Recursive derivative validation",
+      "description": "Validate derivatives recursively (disabled by --prune).",
+      "type": "Flag",
+      "command-line-flag": "--recursive",
+      "value-key": "[RECURSIVE]",
+      "optional": true
+    },
+    {
+      "id": "prune",
+      "name": "Prune sourcedata, derivatives, and code",
+      "description": "Skip the sourcedata, derivatives, and code directories. Disables recursive derivative validation.",
+      "type": "Flag",
+      "command-line-flag": "--prune",
+      "value-key": "[PRUNE]",
+      "optional": true
+    },
+    {
+      "id": "outfile",
+      "name": "Output file",
+      "description": "Write the validation results to a file. Only writes a file when running under Deno; otherwise output goes to stdout.",
+      "type": "String",
+      "command-line-flag": "--outfile",
+      "value-key": "[OUTFILE]",
+      "optional": true
+    },
+    {
+      "id": "preferred_remote",
+      "name": "Preferred remote source",
+      "description": "Prefer a remote file source over local files.",
+      "type": "String",
+      "command-line-flag": "--preferredRemote",
+      "value-key": "[PREFERRED_REMOTE]",
+      "optional": true
+    },
+    {
+      "id": "color",
+      "name": "Color output",
+      "description": "Enable/disable color output (defaults to detected support).",
+      "type": "String",
+      "value-choices": [
+        "--color",
+        "--no-color"
+      ],
+      "value-key": "[COLOR]",
+      "optional": true
+    }
+  ],
+  "output-files": [
+    {
+      "id": "validation_report_file",
+      "name": "Validation report file",
+      "description": "Validation results written to the path supplied by --outfile when running under Deno.",
+      "path-template": "[OUTFILE]"
+    }
+  ],
+  "stdout-output": {
+    "id": "stdout_report",
+    "name": "Validation report (stdout)",
+    "description": "Formatted validation report printed to stdout when --outfile is not provided or the Deno runtime is unavailable."
+  },
+  "name": "bids-validator-deno",
+  "schema-version": "0.5+styx"
+}

--- a/src/niwrap/bidsvalidator/2.4.1/version.json
+++ b/src/niwrap/bidsvalidator/2.4.1/version.json
@@ -1,0 +1,20 @@
+{
+  "name": "2.4.1",
+  "container": "bids/validator:2.4.1",
+  "apps": [
+    "bids-validator-deno"
+  ],
+  "executables": {
+    "required": [
+      "bids-validator-deno"
+    ]
+  },
+  "sources": [
+    {
+      "repo": "https://github.com/bids-standard/bids-validator",
+      "ref": "94ea9719efbbac7531fed8ad8a2a7bf764cee51f",
+      "role": "primary",
+      "note": ""
+    }
+  ]
+}

--- a/src/niwrap/bidsvalidator/package.json
+++ b/src/niwrap/bidsvalidator/package.json
@@ -19,6 +19,9 @@
       "https://bids-validator.readthedocs.io/en/latest/",
       "https://zenodo.org/records/3688707"
     ],
-    "literature": []
+    "literature": [
+      "Gorgolewski, K. J., Alfaro-Almagro, F., Auer, T., Bellec, P., Capotă, M., Chakravarty, M. M., ... & Poldrack, R. A. (2017). BIDS apps: Improving ease of use, accessibility, and reproducibility of neuroimaging data analysis methods. PLoS computational biology, 13(3), e1005209. doi: 10.1371/journal.pcbi.1005209",
+      "Gorgolewski, K. J., Auer, T., Calhoun, V. D., Craddock, R. C., Das, S., Duff, E. P., ... & Poldrack, R. A. (2016). The brain imaging data structure, a format for organizing and describing outputs of neuroimaging experiments. Scientific data, 3(1), 1-9."
+    ]
   }
 }

--- a/src/niwrap/bidsvalidator/package.json
+++ b/src/niwrap/bidsvalidator/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "bidsvalidator",
+  "neurodeskId": "",
+  "versions": [
+    "2.4.1"
+  ],
+  "default": "2.4.1",
+  "docs": {
+    "title": "bidsvalidator",
+    "description": "The BIDS Validator is a web application, command-line utility, and Javascript/Typescript library for assessing compliance with the Brain Imaging Data Structure (BIDS) standard.",
+    "authors": [
+      "bids-standard"
+    ],
+    "affiliation": [
+      "BIDS Community"
+    ],
+    "urls": [
+      "https://github.com/bids-standard/bids-validator",
+      "https://bids-validator.readthedocs.io/en/latest/",
+      "https://zenodo.org/records/3688707"
+    ],
+    "literature": []
+  }
+}

--- a/src/niwrap/project.json
+++ b/src/niwrap/project.json
@@ -5,6 +5,7 @@
   "packages": [
     "afni",
     "ants",
+    "bidsvalidator",
     "c3d",
     "dcm2niix",
     "fastsurfer",


### PR DESCRIPTION
This adds a descriptor for the [bids-validator (v2.4.1)](https://github.com/bids-standard/bids-validator/tree/2.4.1) - v3.x is in alpha.

Note the commit message from 3ccc8f382dce1a6cf584013653368c9823342544:

> Currently only works for the LocalRunner. Container runners call the bids-validator.js directly in their entrypoint and has no `bids-validator-deno` command.

So, currently I think the way to use it would be to `pip install bids-validator-deno` and then use the NiWrap interface with `LocalRunner`.

_Partially addresses #301_