### PR TITLE
chore: update compiler repo URLs for styx-ts -> styx rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ niwrap$use_docker(
 
 ## 🔍 How It Works
 
-NiWrap is powered by the [Styx](https://github.com/styx-api/styx-ts) compiler, which transforms structured descriptors (using the [Boutiques](https://boutiques.github.io/) standard) into type-safe language bindings. This repository contains the descriptors; the compiled packages are published to [PyPI](https://pypi.org/project/niwrap/) (`pip install niwrap`) and [npm](https://www.npmjs.com/package/niwrap) (`npm install niwrap`).
+NiWrap is powered by the [Styx](https://github.com/styx-api/styx) compiler, which transforms structured descriptors (using the [Boutiques](https://boutiques.github.io/) standard) into type-safe language bindings. This repository contains the descriptors; the compiled packages are published to [PyPI](https://pypi.org/project/niwrap/) (`pip install niwrap`) and [npm](https://www.npmjs.com/package/niwrap) (`npm install niwrap`).
 
 ## 📚 Documentation
 
@@ -273,7 +273,7 @@ If you use NiWrap in your research, please consider citing:
 
 ## 🔗 Related Projects
 
-- [Styx Compiler](https://github.com/styx-api/styx-ts)
+- [Styx Compiler](https://github.com/styx-api/styx)
 - [Styx Documentation](https://styx-api.github.io/styxbook/)
 - [Boutiques](https://boutiques.github.io/)
 

--- a/extraction/mrtrix/README.md
+++ b/extraction/mrtrix/README.md
@@ -104,7 +104,7 @@ interpret the interface — that is the frontend's job; input/output file semant
 ## Compile
 
 The dumps are compiled to IR by styx2's `mrtrix` / `argdump` frontends (in
-[`@styx-api/core`](https://github.com/styx-api/styx-ts)), selected per command by
+[`@styx-api/core`](https://github.com/styx-api/styx)), selected per command by
 `app.json`'s `source.type`. `argdump` (argparse JSON → IR) is reusable for any
 argparse-based CLI. A few commands whose flat dump can't express paired
 input/output positionals (`dwi2fod`, `mtnormalise`) are split in

--- a/tooling/compile.sh
+++ b/tooling/compile.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Compile the NiWrap catalog into per-language distributions with styx2 (the
-# styx-ts compiler), then reshape the output into the dist/ layout that the
+# styx compiler), then reshape the output into the dist/ layout that the
 # compile + publish workflows push to the styx-api/niwrap-* repos.
 #
 # This replaces the v1 `wrap build` command: compilation is now owned by the
@@ -12,18 +12,18 @@
 #   targets  comma-separated styx2 backends (default: python,typescript,json-schema)
 #
 # Env overrides:
-#   STYX2_REF   styx-ts git ref to build (default: pinned SHA below)
-#   STYX2_REPO  styx-ts repo URL (default: the public repo)
+#   STYX2_REF   styx git ref to build (default: pinned SHA below)
+#   STYX2_REPO  styx repo URL (default: the public repo)
 #
 # Run from the niwrap repo root.
 set -euo pipefail
 
 # -----------------------------------------------------------------------------
-# Pin: the styx-ts commit the catalog is compiled with. Kept at a fixed SHA so
+# Pin: the styx commit the catalog is compiled with. Kept at a fixed SHA so
 # releases are reproducible; bump deliberately and coordinate with the hub's
 # bundled @styx/core version (see the styx2 v1-replacement plan).
 #
-# Pinned to styx-ts main at the 0.6.1 release (#53) - a patch over 0.6.0 (#48,
+# Pinned to styx main at the 0.6.1 release (#53) - a patch over 0.6.0 (#48,
 # nested `_params` factories + snake_case kwargs) bundling two codegen fixes:
 #   - #49 (boutiques): a `command-line-flag-separator` flag and its value now
 #     fuse into a single argv token (e.g. `--imain=<file>`) instead of two
@@ -34,7 +34,7 @@ set -euo pipefail
 # Keep in lockstep with the hub-gate / DEFAULT_COMPILER @styx-api/core@0.6.1
 # pin; bump deliberately.
 # -----------------------------------------------------------------------------
-STYX2_REPO="${STYX2_REPO:-https://github.com/styx-api/styx-ts.git}"
+STYX2_REPO="${STYX2_REPO:-https://github.com/styx-api/styx.git}"
 STYX2_REF="${STYX2_REF:-9f7b7102ac90517e31c1f44435a0a490eb567edd}"
 
 TARGETS="${1:-python,typescript,json-schema}"
@@ -56,7 +56,7 @@ trap 'rm -rf "${STYX2_DIR:-}" "${BUILD_OUT:-}"' EXIT
 # -----------------------------------------------------------------------------
 # Build the styx2 compiler at the pinned ref.
 # -----------------------------------------------------------------------------
-echo "==> Cloning styx-ts @ ${STYX2_REF}"
+echo "==> Cloning styx @ ${STYX2_REF}"
 git clone --quiet "$STYX2_REPO" "$STYX2_DIR"
 git -C "$STYX2_DIR" checkout --quiet "$STYX2_REF"
 


### PR DESCRIPTION
The compiler repo was renamed from `styx-api/styx-ts` to `styx-api/styx` (the legacy v1 Python compiler now lives at `styx-api/styx-legacy`). Updates the default clone URL in `tooling/compile.sh` plus README links. The pinned SHA is unchanged, and the old URL keeps working via GitHub's rename redirect, so builds are unaffected either way.